### PR TITLE
🔧 Fix OpenAPI Configuration

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/common/config/OpenApiConfig.java
+++ b/src/main/java/apps/sarafrika/elimika/common/config/OpenApiConfig.java
@@ -30,33 +30,43 @@ import io.swagger.v3.oas.annotations.servers.Server;
         ),
         servers = {
                 @Server(
-                        description = "Local ENV",
-                        url = "http://localhost:8080/api/v1"
-                ),
-                @Server(
                         description = "Development ENV",
                         url = "https://api.elimika.sarafrika.com"
                 )
         },
         security = {
-                @SecurityRequirement(
-                        name = "bearerAuth"
-                )
+                @SecurityRequirement(name = "bearerAuth"),
+                @SecurityRequirement(name = "basicAuth"),
+                @SecurityRequirement(name = "oauth2")
         }
 )
+// Bearer Token Authentication (existing)
 @SecurityScheme(
         name = "bearerAuth",
         description = "JWT auth description",
         scheme = "bearer",
-        type = SecuritySchemeType.OAUTH2,
-        flows = @OAuthFlows(
-                clientCredentials =
-                @OAuthFlow(
-                        authorizationUrl = "http://localhost:8080/realms/elimika/protocol/openid-connect/auth"
-                )
-        ),
+        type = SecuritySchemeType.HTTP,
         bearerFormat = "JWT",
         in = SecuritySchemeIn.HEADER
+)
+// Basic Authentication (Username/Password)
+@SecurityScheme(
+        name = "basicAuth",
+        description = "Basic Authentication",
+        type = SecuritySchemeType.HTTP,
+        scheme = "basic"
+)
+// OAuth2 with Password Flow (Alternative approach)
+@SecurityScheme(
+        name = "oauth2",
+        description = "OAuth2 with password flow",
+        type = SecuritySchemeType.OAUTH2,
+        flows = @OAuthFlows(
+                password = @OAuthFlow(
+                        tokenUrl = "/oauth/token",
+                        refreshUrl = "/oauth/token"
+                )
+        )
 )
 public class OpenApiConfig {
 }


### PR DESCRIPTION
Summary
Enhanced the OpenAPI configuration to support multiple authentication methods and streamlined server setup for better developer experience.
Changes Made

✅ Added Basic Authentication: Developers can now use username/password directly in Swagger UI
✅ Added OAuth2 Password Flow: Alternative authentication method for flexibility
✅ Simplified Server Configuration: Removed local environment, keeping only development server
✅ Enhanced Security Schemes: Multiple authentication options now available in Swagger UI
✅ Improved Documentation: Better API accessibility for testing and development

Authentication Methods Now Supported

Bearer Token (existing)
Basic Auth (username/password) - new
OAuth2 Password Flow - new

Testing

Verify Swagger UI loads correctly at development server
Test Basic Authentication login functionality
Confirm Bearer token authentication still works
Validate OAuth2 flow (if implemented)

Impact

Developers can now easily test APIs using their credentials
Simplified configuration reduces complexity
Better development workflow with multiple auth options