### PR TITLE
Fix CategoryRepository Method Signatures and Add Hierarchy Query

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/course/repository/CategoryRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/course/repository/CategoryRepository.java
@@ -3,6 +3,8 @@ package apps.sarafrika.elimika.course.repository;
 import apps.sarafrika.elimika.course.model.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,6 +13,7 @@ import java.util.UUID;
 
 @Repository
 public interface CategoryRepository extends JpaRepository<Category, Long>, JpaSpecificationExecutor<Category> {
+
     Optional<Category> findByUuid(UUID uuid);
 
     Optional<Category> findByName(String name);
@@ -19,13 +22,32 @@ public interface CategoryRepository extends JpaRepository<Category, Long>, JpaSp
 
     boolean existsByUuid(UUID uuid);
 
-    Optional<Category> findByParentUuidIsNull();
+    List<Category> findByParentUuidIsNull();
 
-    Optional<Category> findByParentUuid(UUID uuid);
+    List<Category> findByParentUuid(UUID uuid);
 
-    Optional<Category> findByIsActiveTrue();
+    List<Category> findByIsActiveTrue();
 
-    List<Category> findCategoryHierarchy(UUID categoryUuid);
+    @Query(value = """
+            WITH RECURSIVE category_hierarchy AS (
+                -- Base case: start with the given category
+                SELECT uuid, name, description, parent_uuid, is_active, 
+                       created_date, updated_date, created_by, updated_by, id, 0 as level
+                FROM course_categories 
+                WHERE uuid = :categoryUuid
+                
+                UNION ALL
+                
+                -- Recursive case: find all children
+                SELECT c.uuid, c.name, c.description, c.parent_uuid, c.is_active,
+                       c.created_date, c.updated_date, c.created_by, c.updated_by, c.id, ch.level + 1
+                FROM course_categories c
+                INNER JOIN category_hierarchy ch ON c.parent_uuid = ch.uuid
+            )
+            SELECT * FROM category_hierarchy
+            ORDER BY level, name
+            """, nativeQuery = true)
+    List<Category> findCategoryHierarchy(@Param("categoryUuid") UUID categoryUuid);
 
     long countByParentUuid(UUID categoryUuid);
 }


### PR DESCRIPTION
## 🐛 Problem
The application was failing to start due to multiple issues in the `CategoryRepository`:

1. **Missing @Query Annotation Error:**
   ```
   PropertyReferenceException: No property 'findCategoryHierarchy' found for type 'Category'
   ```

2. **Repository-Service Type Mismatches:** Service methods expected `List<Category>` but repository methods were returning `Optional<Category>` for queries that logically return multiple results.

## 🔧 Changes Made

### 1. Fixed Return Type Mismatches
Updated repository methods to return appropriate collection types:

**BEFORE**
```java
Optional<Category> findByParentUuidIsNull();  // Root categories
Optional<Category> findByParentUuid(UUID uuid);  // Subcategories  
Optional<Category> findByIsActiveTrue();  // Active categories
```

**AFTER**
```java
List<Category> findByParentUuidIsNull();  // Root categories
List<Category> findByParentUuid(UUID uuid);  // Subcategories
List<Category> findByIsActiveTrue();  // Active categories
```

### 2. Added Custom Hierarchy Query
Implemented proper category hierarchy traversal with `@Query` annotation:

**BEFORE**
```java
List<Category> findCategoryHierarchy(UUID categoryUuid);  // No @Query annotation
```

**AFTER**
```java
@Query(value = """
        WITH RECURSIVE category_hierarchy AS (
            -- Base case: start with the given category
            SELECT uuid, name, description, parent_uuid, is_active, 
                   created_date, updated_date, created_by, updated_by, id, 0 as level
            FROM course_categories 
            WHERE uuid = :categoryUuid
            
            UNION ALL
            
            -- Recursive case: find all children
            SELECT c.uuid, c.name, c.description, c.parent_uuid, c.is_active,
                   c.created_date, c.updated_date, c.created_by, c.updated_by, c.id, ch.level + 1
            FROM course_categories c
            INNER JOIN category_hierarchy ch ON c.parent_uuid = ch.uuid
        )
        SELECT * FROM category_hierarchy
        ORDER BY level, name
        """, nativeQuery = true)
List<Category> findCategoryHierarchy(@Param("categoryUuid") UUID categoryUuid);
```

## 🎯 Root Cause Analysis

1. **Logical Inconsistency**: Repository methods for multi-result queries were using `Optional<Category>` instead of `List<Category>`
2. **Missing Custom Query**: Spring Data JPA couldn't derive query for complex hierarchy method name
3. **Service-Repository Mismatch**: Service layer expected collections but got optionals

## 🚀 Improvements Made

- **Logical Consistency**: Repository methods now return appropriate types for their use cases
- **Hierarchical Queries**: Proper recursive CTE implementation for category tree traversal
- **Performance**: Optimized hierarchy query with level ordering
- **Service Compatibility**: Repository signatures now match service layer expectations

## ✅ Impact

- ✅ Application now starts successfully
- ✅ Repository methods return logically correct types
- ✅ Category hierarchy queries work with proper recursion
- ✅ Service layer methods function as expected
- ✅ No breaking changes to public service interface

## 🧪 Affected Service Methods

The following service methods now work correctly:
- `getRootCategories()` - Returns list of root categories
- `getSubCategories(UUID)` - Returns list of subcategories
- `getActiveCategories()` - Returns list of active categories
- `getCategoryHierarchy(UUID)` - Returns hierarchical category tree

## 🧪 Testing

- [x] Application starts without PropertyReferenceException
- [x] Repository methods return correct collection types
- [x] Category hierarchy query executes successfully
- [x] Service layer methods work with updated repository signatures
- [ ] Integration tests for category hierarchy traversal (follow-up)

## 🔗 Related Issues

- Fixes application startup failure
- Part of broader repository query method standardization
- Enables proper category management functionality

## 📝 Commit Message

```
fix: correct CategoryRepository method signatures and add missing @Query annotation

- Change findByParentUuidIsNull() return type from Optional<Category> to List<Category>
- Change findByParentUuid() return type from Optional<Category> to List<Category>  
- Change findByIsActiveTrue() return type from Optional<Category> to List<Category>
- Add @Query annotation with recursive CTE for findCategoryHierarchy() method
- Implement proper category hierarchy traversal using PostgreSQL WITH RECURSIVE
- Ensure repository methods match service layer expectations

Resolves PropertyReferenceException and fixes Spring Boot application startup failure.
Repository methods now correctly return lists for multi-result queries and use explicit
queries for complex hierarchy operations.
```