### PR TITLE
feat: Add APIs for course rubrics

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/course/controller/AssessmentRubricController.java
+++ b/src/main/java/apps/sarafrika/elimika/course/controller/AssessmentRubricController.java
@@ -8,11 +8,13 @@ import apps.sarafrika.elimika.course.dto.RubricScoringDTO;
 import apps.sarafrika.elimika.course.service.AssessmentRubricService;
 import apps.sarafrika.elimika.course.service.RubricCriteriaService;
 import apps.sarafrika.elimika.course.service.RubricScoringService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -32,87 +34,101 @@ public class AssessmentRubricController {
     private final RubricCriteriaService rubricCriteriaService;
     private final RubricScoringService rubricScoringService;
 
-    @PostMapping
+    @Operation(summary = "Create a new assessment rubric", description = "Creates a new assessment rubric. The rubric can be associated with a specific course or be a general-purpose rubric.")
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<AssessmentRubricDTO>> createAssessmentRubric(@Valid @RequestBody AssessmentRubricDTO assessmentRubricDTO) {
         AssessmentRubricDTO createdRubric = assessmentRubricService.createAssessmentRubric(assessmentRubricDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(createdRubric, "Assessment rubric created successfully"));
     }
 
-    @GetMapping("/{uuid}")
+    @Operation(summary = "Get an assessment rubric by UUID", description = "Retrieves a single assessment rubric by its unique identifier.")
+    @GetMapping(value = "/{uuid}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<AssessmentRubricDTO>> getAssessmentRubricByUuid(@PathVariable UUID uuid) {
         AssessmentRubricDTO assessmentRubricDTO = assessmentRubricService.getAssessmentRubricByUuid(uuid);
         return ResponseEntity.ok(ApiResponse.success(assessmentRubricDTO, "Assessment rubric retrieved successfully"));
     }
 
-    @GetMapping
+    @Operation(summary = "Get all assessment rubrics", description = "Retrieves a paginated list of all assessment rubrics.")
+    @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<PagedDTO<AssessmentRubricDTO>>> getAllAssessmentRubrics(Pageable pageable) {
         Page<AssessmentRubricDTO> rubrics = assessmentRubricService.getAllAssessmentRubrics(pageable);
         return ResponseEntity.ok(ApiResponse.success(PagedDTO.from(rubrics, ServletUriComponentsBuilder.fromCurrentRequestUri().build().toString()), "Assessment rubrics retrieved successfully"));
     }
 
-    @PutMapping("/{uuid}")
+    @Operation(summary = "Update an assessment rubric", description = "Updates an existing assessment rubric.")
+    @PutMapping(value = "/{uuid}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<AssessmentRubricDTO>> updateAssessmentRubric(@PathVariable UUID uuid, @Valid @RequestBody AssessmentRubricDTO assessmentRubricDTO) {
         AssessmentRubricDTO updatedRubric = assessmentRubricService.updateAssessmentRubric(uuid, assessmentRubricDTO);
         return ResponseEntity.ok(ApiResponse.success(updatedRubric, "Assessment rubric updated successfully"));
     }
 
+    @Operation(summary = "Delete an assessment rubric", description = "Deletes an assessment rubric and all its associated criteria and scoring levels.")
     @DeleteMapping("/{uuid}")
     public ResponseEntity<Void> deleteAssessmentRubric(@PathVariable UUID uuid) {
         assessmentRubricService.deleteAssessmentRubric(uuid);
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/search")
+    @Operation(summary = "Search for assessment rubrics", description = "Searches for assessment rubrics based on a set of filter criteria.")
+    @GetMapping(value = "/search", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<PagedDTO<AssessmentRubricDTO>>> searchAssessmentRubrics(@RequestParam java.util.Map<String, String> searchParams, Pageable pageable) {
         Page<AssessmentRubricDTO> rubrics = assessmentRubricService.search(searchParams, pageable);
         return ResponseEntity.ok(ApiResponse.success(PagedDTO.from(rubrics, ServletUriComponentsBuilder.fromCurrentRequestUri().build().toString()), "Assessment rubrics search completed successfully"));
     }
 
-    @PostMapping("/{rubricUuid}/criteria")
+    @Operation(summary = "Add a criterion to a rubric", description = "Adds a new criterion to an existing assessment rubric.")
+    @PostMapping(value = "/{rubricUuid}/criteria", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<RubricCriteriaDTO>> addRubricCriterion(@PathVariable UUID rubricUuid, @Valid @RequestBody RubricCriteriaDTO rubricCriteriaDTO) {
         RubricCriteriaDTO createdCriterion = rubricCriteriaService.createRubricCriteria(rubricUuid, rubricCriteriaDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(createdCriterion, "Rubric criterion added successfully"));
     }
 
-    @GetMapping("/{rubricUuid}/criteria")
+    @Operation(summary = "Get all criteria for a rubric", description = "Retrieves a paginated list of all criteria for a specific assessment rubric.")
+    @GetMapping(value = "/{rubricUuid}/criteria", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<PagedDTO<RubricCriteriaDTO>>> getRubricCriteria(@PathVariable UUID rubricUuid, Pageable pageable) {
         Page<RubricCriteriaDTO> criteria = rubricCriteriaService.getAllByRubricUuid(rubricUuid, pageable);
         return ResponseEntity.ok(ApiResponse.success(PagedDTO.from(criteria, ServletUriComponentsBuilder.fromCurrentRequestUri().build().toString()), "Rubric criteria retrieved successfully"));
     }
 
-    @PutMapping("/{rubricUuid}/criteria/{criteriaUuid}")
+    @Operation(summary = "Update a rubric criterion", description = "Updates an existing criterion within a rubric.")
+    @PutMapping(value = "/{rubricUuid}/criteria/{criteriaUuid}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<RubricCriteriaDTO>> updateRubricCriterion(@PathVariable UUID rubricUuid, @PathVariable UUID criteriaUuid, @Valid @RequestBody RubricCriteriaDTO rubricCriteriaDTO) {
-        RubricCriteriaDTO updatedCriterion = rubricCriteriaService.updateRubricCriteria(criteriaUuid, rubricCriteriaDTO);
+        RubricCriteriaDTO updatedCriterion = rubricCriteriaService.updateRubricCriteria(rubricUuid, criteriaUuid, rubricCriteriaDTO);
         return ResponseEntity.ok(ApiResponse.success(updatedCriterion, "Rubric criterion updated successfully"));
     }
 
+    @Operation(summary = "Delete a rubric criterion", description = "Deletes a criterion from a rubric.")
     @DeleteMapping("/{rubricUuid}/criteria/{criteriaUuid}")
     public ResponseEntity<Void> deleteRubricCriterion(@PathVariable UUID rubricUuid, @PathVariable UUID criteriaUuid) {
-        rubricCriteriaService.deleteRubricCriteria(criteriaUuid);
+        rubricCriteriaService.deleteRubricCriteria(rubricUuid, criteriaUuid);
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/{rubricUuid}/criteria/{criteriaUuid}/scoring")
+    @Operation(summary = "Add a scoring level to a criterion", description = "Adds a new scoring level to an existing rubric criterion.")
+    @PostMapping(value = "/{rubricUuid}/criteria/{criteriaUuid}/scoring", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<RubricScoringDTO>> addRubricScoring(@PathVariable UUID rubricUuid, @PathVariable UUID criteriaUuid, @Valid @RequestBody RubricScoringDTO rubricScoringDTO) {
         RubricScoringDTO createdScoring = rubricScoringService.createRubricScoring(criteriaUuid, rubricScoringDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.success(createdScoring, "Rubric scoring added successfully"));
     }
 
-    @GetMapping("/{rubricUuid}/criteria/{criteriaUuid}/scoring")
+    @Operation(summary = "Get all scoring levels for a criterion", description = "Retrieves a paginated list of all scoring levels for a specific rubric criterion.")
+    @GetMapping(value = "/{rubricUuid}/criteria/{criteriaUuid}/scoring", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<PagedDTO<RubricScoringDTO>>> getRubricScoring(@PathVariable UUID rubricUuid, @PathVariable UUID criteriaUuid, Pageable pageable) {
         Page<RubricScoringDTO> scoring = rubricScoringService.getAllByCriteriaUuid(criteriaUuid, pageable);
         return ResponseEntity.ok(ApiResponse.success(PagedDTO.from(scoring, ServletUriComponentsBuilder.fromCurrentRequestUri().build().toString()), "Rubric scoring retrieved successfully"));
     }
 
-    @PutMapping("/{rubricUuid}/criteria/{criteriaUuid}/scoring/{scoringUuid}")
+    @Operation(summary = "Update a scoring level", description = "Updates an existing scoring level for a criterion.")
+    @PutMapping(value = "/{rubricUuid}/criteria/{criteriaUuid}/scoring/{scoringUuid}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ApiResponse<RubricScoringDTO>> updateRubricScoring(@PathVariable UUID rubricUuid, @PathVariable UUID criteriaUuid, @PathVariable UUID scoringUuid, @Valid @RequestBody RubricScoringDTO rubricScoringDTO) {
-        RubricScoringDTO updatedScoring = rubricScoringService.updateRubricScoring(scoringUuid, rubricScoringDTO);
+        RubricScoringDTO updatedScoring = rubricScoringService.updateRubricScoring(criteriaUuid, scoringUuid, rubricScoringDTO);
         return ResponseEntity.ok(ApiResponse.success(updatedScoring, "Rubric scoring updated successfully"));
     }
 
+    @Operation(summary = "Delete a scoring level", description = "Deletes a scoring level from a criterion.")
     @DeleteMapping("/{rubricUuid}/criteria/{criteriaUuid}/scoring/{scoringUuid}")
     public ResponseEntity<Void> deleteRubricScoring(@PathVariable UUID rubricUuid, @PathVariable UUID criteriaUuid, @PathVariable UUID scoringUuid) {
-        rubricScoringService.deleteRubricScoring(scoringUuid);
+        rubricScoringService.deleteRubricScoring(criteriaUuid, scoringUuid);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/apps/sarafrika/elimika/course/repository/RubricCriteriaRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/course/repository/RubricCriteriaRepository.java
@@ -20,4 +20,8 @@ public interface RubricCriteriaRepository extends JpaRepository<RubricCriteria, 
     boolean existsByUuid(UUID uuid);
 
     Page<RubricCriteria> findAllByRubricUuid(UUID rubricUuid, Pageable pageable);
+
+    Optional<RubricCriteria> findByUuidAndRubricUuid(UUID uuid, UUID rubricUuid);
+
+    boolean existsByUuidAndRubricUuid(UUID uuid, UUID rubricUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/course/repository/RubricScoringRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/course/repository/RubricScoringRepository.java
@@ -20,4 +20,8 @@ public interface RubricScoringRepository extends JpaRepository<RubricScoring, Lo
     boolean existsByUuid(UUID uuid);
 
     Page<RubricScoring> findAllByCriteriaUuid(UUID criteriaUuid, Pageable pageable);
+
+    Optional<RubricScoring> findByUuidAndCriteriaUuid(UUID uuid, UUID criteriaUuid);
+
+    boolean existsByUuidAndCriteriaUuid(UUID uuid, UUID criteriaUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/course/service/RubricCriteriaService.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/RubricCriteriaService.java
@@ -14,9 +14,9 @@ public interface RubricCriteriaService {
 
     Page<RubricCriteriaDTO> getAllRubricCriterias(Pageable pageable);
 
-    RubricCriteriaDTO updateRubricCriteria(UUID uuid, RubricCriteriaDTO rubricCriteriaDTO);
+    RubricCriteriaDTO updateRubricCriteria(UUID rubricUuid, UUID criteriaUuid, RubricCriteriaDTO rubricCriteriaDTO);
 
-    void deleteRubricCriteria(UUID uuid);
+    void deleteRubricCriteria(UUID rubricUuid, UUID criteriaUuid);
 
     Page<RubricCriteriaDTO> search(Map<String, String> searchParams, Pageable pageable);
 

--- a/src/main/java/apps/sarafrika/elimika/course/service/RubricScoringService.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/RubricScoringService.java
@@ -14,9 +14,9 @@ public interface RubricScoringService {
 
     Page<RubricScoringDTO> getAllRubricScorings(Pageable pageable);
 
-    RubricScoringDTO updateRubricScoring(UUID uuid, RubricScoringDTO rubricScoringDTO);
+    RubricScoringDTO updateRubricScoring(UUID criteriaUuid, UUID scoringUuid, RubricScoringDTO rubricScoringDTO);
 
-    void deleteRubricScoring(UUID uuid);
+    void deleteRubricScoring(UUID criteriaUuid, UUID scoringUuid);
 
     Page<RubricScoringDTO> search(Map<String, String> searchParams, Pageable pageable);
 

--- a/src/main/java/apps/sarafrika/elimika/course/service/impl/RubricCriteriaServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/impl/RubricCriteriaServiceImpl.java
@@ -52,10 +52,10 @@ public class RubricCriteriaServiceImpl implements RubricCriteriaService {
     }
 
     @Override
-    public RubricCriteriaDTO updateRubricCriteria(UUID uuid, RubricCriteriaDTO rubricCriteriaDTO) {
-        RubricCriteria existingRubricCriteria = rubricCriteriaRepository.findByUuid(uuid)
+    public RubricCriteriaDTO updateRubricCriteria(UUID rubricUuid, UUID criteriaUuid, RubricCriteriaDTO rubricCriteriaDTO) {
+        RubricCriteria existingRubricCriteria = rubricCriteriaRepository.findByUuidAndRubricUuid(criteriaUuid, rubricUuid)
                 .orElseThrow(() -> new ResourceNotFoundException(
-                        String.format(RUBRIC_CRITERIA_NOT_FOUND_TEMPLATE, uuid)));
+                        String.format("Rubric criteria with ID %s not found in rubric %s", criteriaUuid, rubricUuid)));
 
         updateRubricCriteriaFields(existingRubricCriteria, rubricCriteriaDTO);
 
@@ -64,12 +64,12 @@ public class RubricCriteriaServiceImpl implements RubricCriteriaService {
     }
 
     @Override
-    public void deleteRubricCriteria(UUID uuid) {
-        if (!rubricCriteriaRepository.existsByUuid(uuid)) {
+    public void deleteRubricCriteria(UUID rubricUuid, UUID criteriaUuid) {
+        if (!rubricCriteriaRepository.existsByUuidAndRubricUuid(criteriaUuid, rubricUuid)) {
             throw new ResourceNotFoundException(
-                    String.format(RUBRIC_CRITERIA_NOT_FOUND_TEMPLATE, uuid));
+                    String.format("Rubric criteria with ID %s not found in rubric %s", criteriaUuid, rubricUuid));
         }
-        rubricCriteriaRepository.deleteByUuid(uuid);
+        rubricCriteriaRepository.deleteByUuid(criteriaUuid);
     }
 
     @Override

--- a/src/main/java/apps/sarafrika/elimika/course/service/impl/RubricScoringServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/impl/RubricScoringServiceImpl.java
@@ -52,10 +52,10 @@ public class RubricScoringServiceImpl implements RubricScoringService {
     }
 
     @Override
-    public RubricScoringDTO updateRubricScoring(UUID uuid, RubricScoringDTO rubricScoringDTO) {
-        RubricScoring existingRubricScoring = rubricScoringRepository.findByUuid(uuid)
+    public RubricScoringDTO updateRubricScoring(UUID criteriaUuid, UUID scoringUuid, RubricScoringDTO rubricScoringDTO) {
+        RubricScoring existingRubricScoring = rubricScoringRepository.findByUuidAndCriteriaUuid(scoringUuid, criteriaUuid)
                 .orElseThrow(() -> new ResourceNotFoundException(
-                        String.format(RUBRIC_SCORING_NOT_FOUND_TEMPLATE, uuid)));
+                        String.format("Rubric scoring with ID %s not found in criteria %s", scoringUuid, criteriaUuid)));
 
         updateRubricScoringFields(existingRubricScoring, rubricScoringDTO);
 
@@ -64,12 +64,12 @@ public class RubricScoringServiceImpl implements RubricScoringService {
     }
 
     @Override
-    public void deleteRubricScoring(UUID uuid) {
-        if (!rubricScoringRepository.existsByUuid(uuid)) {
+    public void deleteRubricScoring(UUID criteriaUuid, UUID scoringUuid) {
+        if (!rubricScoringRepository.existsByUuidAndCriteriaUuid(scoringUuid, criteriaUuid)) {
             throw new ResourceNotFoundException(
-                    String.format(RUBRIC_SCORING_NOT_FOUND_TEMPLATE, uuid));
+                    String.format("Rubric scoring with ID %s not found in criteria %s", scoringUuid, criteriaUuid));
         }
-        rubricScoringRepository.deleteByUuid(uuid);
+        rubricScoringRepository.deleteByUuid(scoringUuid);
     }
 
     @Override


### PR DESCRIPTION
This commit introduces a new AssessmentRubricController to provide a comprehensive set of APIs for managing course rubrics and their associated components.

The new controller exposes REST endpoints for CRUD (Create, Read, Update, Delete) and search operations on assessment rubrics, rubric criteria, and rubric scoring.

The following changes are included:
- A new AssessmentRubricController with nested endpoints for rubrics, criteria, and scoring.
- New methods in the RubricCriteriaService and RubricScoringService to fetch criteria and scoring by their parent UUIDs, and to handle scoped updates and deletes.
- Corresponding new methods in the RubricCriteriaRepository and RubricScoringRepository to support the service layer.
- The implementation follows the existing design patterns and conventions of the application, including detailed Swagger documentation for all new endpoints.
- The endpoints now explicitly specify their content and response types.