### PR TITLE
fix: standardise organisation spelling in public api

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionDTO.java
@@ -124,7 +124,7 @@ public record ClassDefinitionDTO(
         UUID defaultInstructorUuid,
 
         @Schema(
-                description = "**[OPTIONAL]** Reference to the organization UUID that owns this class definition.",
+                description = "**[OPTIONAL]** Reference to the organisation UUID that owns this class definition.",
                 example = "org12345-6789-abcd-ef01-234567890abc",
                 nullable = true,
                 requiredMode = Schema.RequiredMode.NOT_REQUIRED

--- a/src/main/java/apps/sarafrika/elimika/course/dto/LessonContentDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/LessonContentDTO.java
@@ -137,12 +137,11 @@ public record LessonContentDTO(
         String mimeType,
 
         @Schema(
-                description = "**[REQUIRED]** Display order of content within the lesson for sequential presentation.",
+                description = "**[OPTIONAL]** Display order of content within the lesson for sequential presentation. If omitted, the system appends the content at the end.",
                 example = "1",
-                requiredMode = Schema.RequiredMode.REQUIRED,
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED,
                 minimum = "1"
         )
-        @NotNull(message = "Display order is required")
         @Min(value = 1, message = "Display order must be at least 1")
         @JsonProperty("display_order")
         Integer displayOrder,

--- a/src/main/java/apps/sarafrika/elimika/coursecreator/dto/CourseCreatorCertificationDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/coursecreator/dto/CourseCreatorCertificationDTO.java
@@ -22,7 +22,7 @@ import java.util.UUID;
             "uuid": "cert1234-5678-abcd-ef01-234567890abc",
             "course_creator_uuid": "c1r2e3a4-5t6o-7r89-0abc-defghijklmno",
             "certification_name": "Adobe Captivate Specialist",
-            "issuing_organization": "Adobe",
+            "issuing_organisation": "Adobe",
             "issued_date": "2023-04-01",
             "expiry_date": "2025-04-01",
             "credential_id": "ADCAP-2023-8891",
@@ -46,9 +46,9 @@ public record CourseCreatorCertificationDTO(
         @JsonProperty("certification_name")
         String certificationName,
 
-        @NotBlank(message = "Issuing organization is required")
-        @Size(max = 255, message = "Issuing organization must not exceed 255 characters")
-        @JsonProperty("issuing_organization")
+        @NotBlank(message = "Issuing organisation is required")
+        @Size(max = 255, message = "Issuing organisation must not exceed 255 characters")
+        @JsonProperty("issuing_organisation")
         String issuingOrganization,
 
         @JsonProperty("issued_date")

--- a/src/main/java/apps/sarafrika/elimika/coursecreator/dto/CourseCreatorExperienceDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/coursecreator/dto/CourseCreatorExperienceDTO.java
@@ -24,7 +24,7 @@ import java.util.UUID;
             "uuid": "exp12345-6789-abcd-ef01-234567890abc",
             "course_creator_uuid": "c1r2e3a4-5t6o-7r89-0abc-defghijklmno",
             "position": "Lead Content Strategist",
-            "organization_name": "Digital Learning Labs",
+            "organisation_name": "Digital Learning Labs",
             "responsibilities": "Designed blended learning experiences for enterprise teams.",
             "years_of_experience": 5.5,
             "start_date": "2019-01-01",
@@ -46,9 +46,9 @@ public record CourseCreatorExperienceDTO(
         @JsonProperty("position")
         String position,
 
-        @NotBlank(message = "Organization name is required")
-        @Size(max = 255, message = "Organization name must not exceed 255 characters")
-        @JsonProperty("organization_name")
+        @NotBlank(message = "Organisation name is required")
+        @Size(max = 255, message = "Organisation name must not exceed 255 characters")
+        @JsonProperty("organisation_name")
         String organizationName,
 
         @JsonProperty("responsibilities")

--- a/src/main/java/apps/sarafrika/elimika/coursecreator/dto/CourseCreatorProfessionalMembershipDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/coursecreator/dto/CourseCreatorProfessionalMembershipDTO.java
@@ -20,7 +20,7 @@ import java.util.UUID;
         {
             "uuid": "memb1234-5678-abcd-ef01-234567890abc",
             "course_creator_uuid": "c1r2e3a4-5t6o-7r89-0abc-defghijklmno",
-            "organization_name": "International Society for Technology in Education",
+            "organisation_name": "International Society for Technology in Education",
             "membership_number": "ISTE-2024-991",
             "start_date": "2022-01-01",
             "end_date": null,
@@ -37,9 +37,9 @@ public record CourseCreatorProfessionalMembershipDTO(
         @JsonProperty("course_creator_uuid")
         UUID courseCreatorUuid,
 
-        @NotBlank(message = "Organization name is required")
-        @Size(max = 255, message = "Organization name must not exceed 255 characters")
-        @JsonProperty("organization_name")
+        @NotBlank(message = "Organisation name is required")
+        @Size(max = 255, message = "Organisation name must not exceed 255 characters")
+        @JsonProperty("organisation_name")
         String organizationName,
 
         @Size(max = 100, message = "Membership number must not exceed 100 characters")

--- a/src/main/java/apps/sarafrika/elimika/instructor/dto/InstructorExperienceDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/instructor/dto/InstructorExperienceDTO.java
@@ -30,7 +30,7 @@ import java.util.UUID;
             "uuid": "exp12345-6789-abcd-ef01-234567890abc",
             "instructor_uuid": "i1s2t3r4-5u6c-7t8o-9r10-abcdefghijkl",
             "position": "Senior Software Developer",
-            "organization_name": "Safaricom PLC",
+            "organisation_name": "Safaricom PLC",
             "responsibilities": "Led development of mobile banking applications, mentored junior developers, implemented DevOps practices, and collaborated with cross-functional teams to deliver high-quality software solutions.",
             "years_of_experience": 5.5,
             "start_date": "2019-01-15",
@@ -83,14 +83,14 @@ public record InstructorExperienceDTO(
         String position,
 
         @Schema(
-                description = "**[REQUIRED]** Name of the organization, company, or institution where the instructor worked.",
+                description = "**[REQUIRED]** Name of the organisation, company, or institution where the instructor worked.",
                 example = "Safaricom PLC",
                 maxLength = 255,
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotBlank(message = "Organization name is required")
-        @Size(max = 255, message = "Organization name must not exceed 255 characters")
-        @JsonProperty("organization_name")
+        @NotBlank(message = "Organisation name is required")
+        @Size(max = 255, message = "Organisation name must not exceed 255 characters")
+        @JsonProperty("organisation_name")
         String organizationName,
 
         @Schema(

--- a/src/main/java/apps/sarafrika/elimika/instructor/dto/InstructorProfessionalMembershipDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/instructor/dto/InstructorProfessionalMembershipDTO.java
@@ -28,7 +28,7 @@ import java.util.UUID;
         {
             "uuid": "mem12345-6789-abcd-ef01-234567890abc",
             "instructor_uuid": "i1s2t3r4-5u6c-7t8o-9r10-abcdefghijkl",
-            "organization_name": "Institute of Electrical and Electronics Engineers (IEEE)",
+            "organisation_name": "Institute of Electrical and Electronics Engineers (IEEE)",
             "membership_number": "IEEE-92345678",
             "start_date": "2020-03-15",
             "end_date": null,
@@ -43,7 +43,7 @@ import java.util.UUID;
             "is_long_standing_member": true,
             "has_membership_number": true,
             "membership_status": "ACTIVE",
-            "organization_type": "PROFESSIONAL_INSTITUTE",
+            "organisation_type": "PROFESSIONAL_INSTITUTE",
             "years_of_membership": 4.25,
             "is_recent_membership": true
         }
@@ -70,18 +70,18 @@ public record InstructorProfessionalMembershipDTO(
         UUID instructorUuid,
 
         @Schema(
-                description = "**[REQUIRED]** Full name of the professional organization, association, or certification body.",
+                description = "**[REQUIRED]** Full name of the professional organisation, association, or certification body.",
                 example = "Institute of Electrical and Electronics Engineers (IEEE)",
                 maxLength = 255,
                 requiredMode = Schema.RequiredMode.REQUIRED
         )
-        @NotBlank(message = "Organization name is required")
-        @Size(max = 255, message = "Organization name must not exceed 255 characters")
-        @JsonProperty("organization_name")
+        @NotBlank(message = "Organisation name is required")
+        @Size(max = 255, message = "Organisation name must not exceed 255 characters")
+        @JsonProperty("organisation_name")
         String organizationName,
 
         @Schema(
-                description = "**[OPTIONAL]** Official membership number or identifier issued by the organization.",
+                description = "**[OPTIONAL]** Official membership number or identifier issued by the organisation.",
                 example = "IEEE-92345678",
                 maxLength = 100,
                 nullable = true,
@@ -311,9 +311,9 @@ public record InstructorProfessionalMembershipDTO(
      *
      * @return Organization type classification
      */
-    @JsonProperty(value = "organization_type", access = JsonProperty.Access.READ_ONLY)
+    @JsonProperty(value = "organisation_type", access = JsonProperty.Access.READ_ONLY)
     @Schema(
-            description = "**[READ-ONLY]** Classification of organization type based on name keywords.",
+            description = "**[READ-ONLY]** Classification of organisation type based on name keywords.",
             example = "PROFESSIONAL_INSTITUTE",
             allowableValues = {"PROFESSIONAL_INSTITUTE", "CERTIFICATION_BODY", "INDUSTRY_ASSOCIATION", "ACADEMIC_SOCIETY", "TRADE_ORGANIZATION", "OTHER"},
             accessMode = Schema.AccessMode.READ_ONLY

--- a/src/main/java/apps/sarafrika/elimika/shared/controller/CourseController.java
+++ b/src/main/java/apps/sarafrika/elimika/shared/controller/CourseController.java
@@ -26,6 +26,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriUtils;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.HashMap;
@@ -618,6 +619,50 @@ public class CourseController {
         }
     }
 
+    @Operation(
+            summary = "Get uploaded lesson content media",
+            description = """
+                Retrieves uploaded lesson content files by their stored relative path.
+                This is the canonical preview endpoint for course content media such as images,
+                PDFs, audio, and video attached during lesson authoring.
+                """,
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "Lesson content media retrieved successfully",
+                            content = @Content(mediaType = "application/octet-stream")
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "Lesson content media not found",
+                            content = @Content(schema = @Schema(implementation = apps.sarafrika.elimika.shared.dto.ApiResponse.class))
+                    )
+            }
+    )
+    @GetMapping("/content-media/{*filePath}")
+    public ResponseEntity<Resource> getCourseContentMedia(
+            @Parameter(
+                    description = "Stored relative path of the lesson content media file.",
+                    example = "course_materials/course-uuid/lessons/lesson-uuid/file.pdf",
+                    required = true
+            )
+            @PathVariable String filePath) {
+
+        try {
+            Resource resource = storageService.load(filePath);
+            String contentType = storageService.getContentType(filePath);
+            String fileName = filePath.substring(filePath.lastIndexOf('/') + 1);
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(contentType))
+                    .header(HttpHeaders.CACHE_CONTROL, "max-age=3600, must-revalidate")
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + fileName + "\"")
+                    .body(resource);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+    }
+
     // ===== COURSE LESSONS =====
 
     @Operation(
@@ -800,9 +845,7 @@ public class CourseController {
                 + "/lessons/" + lessonUuid;
 
         String storedFileName = storageService.store(file, folder);
-        String fileUrl = storageProperties.getBaseUrl() != null
-                ? storageProperties.getBaseUrl() + "/" + storedFileName
-                : storedFileName;
+        String fileUrl = buildLessonContentMediaUrl(storedFileName);
 
         LessonContentDTO requestDto = new LessonContentDTO(
                 null,
@@ -1355,5 +1398,21 @@ public class CourseController {
         } else {
             return storageProperties.getFolders().getCourseMaterials() + "/" + fileName;
         }
+    }
+
+    private String buildLessonContentMediaUrl(String storedFilePath) {
+        String encodedPath = UriUtils.encodePath(storedFilePath, java.nio.charset.StandardCharsets.UTF_8);
+        String mediaPath = "/api/v1/courses/content-media/" + encodedPath;
+
+        if (storageProperties.getBaseUrl() != null && !storageProperties.getBaseUrl().isEmpty()) {
+            return storageProperties.getBaseUrl() + mediaPath;
+        }
+
+        return ServletUriComponentsBuilder
+                .fromCurrentContextPath()
+                .scheme("https")
+                .path(mediaPath)
+                .build()
+                .toUriString();
     }
 }

--- a/src/main/java/apps/sarafrika/elimika/shared/security/SecurityConfiguration.java
+++ b/src/main/java/apps/sarafrika/elimika/shared/security/SecurityConfiguration.java
@@ -57,6 +57,7 @@ public class SecurityConfiguration {
                                 .requestMatchers(HttpMethod.GET, "/api/v1/organisations").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/users/profile-image/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/courses/media/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/v1/courses/content-media/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/courses/*/reviews").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/assignments/media/**").permitAll()
                                 .requestMatchers(HttpMethod.GET, "/api/v1/commerce/catalogue/**").permitAll()

--- a/src/main/java/apps/sarafrika/elimika/tenancy/controller/AdminController.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/controller/AdminController.java
@@ -60,7 +60,7 @@ public class AdminController {
     @Operation(
             summary = "Assign admin domain to user",
             description = "Assigns admin domain privileges to a user. This grants the user administrative access " +
-                    "either globally (system admin) or within specific organizational contexts. " +
+                    "either globally (system admin) or within specific organisational contexts. " +
                     "Only existing system administrators can perform this operation."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Admin domain assigned successfully")
@@ -155,7 +155,7 @@ public class AdminController {
     @Operation(
             summary = "Get all admin users",
             description = "Retrieves a paginated list of all users with administrative privileges. " +
-                    "Includes both system administrators and organization administrators. " +
+                    "Includes both system administrators and organisation administrators. " +
                     "Supports filtering by admin level, status, and other criteria."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Admin users retrieved successfully")
@@ -204,24 +204,24 @@ public class AdminController {
     }
 
     @Operation(
-            summary = "Get organization admin users",
-            description = "Retrieves a paginated list of users with organization administrator privileges. " +
-                    "These users have administrative access within specific organizational contexts."
+            summary = "Get organisation admin users",
+            description = "Retrieves a paginated list of users with organisation administrator privileges. " +
+                    "These users have administrative access within specific organisational contexts."
     )
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Organization admin users retrieved successfully")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Organisation admin users retrieved successfully")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Insufficient privileges - system admin required")
-    @GetMapping("/users/organization-admins")
+    @GetMapping("/users/organisation-admins")
     public ResponseEntity<ApiResponse<PagedDTO<UserDTO>>> getOrganizationAdminUsers(
             @PageableDefault(size = 20) Pageable pageable) {
 
-        log.debug("Getting organization admin users");
+        log.debug("Getting organisation admin users");
         var orgAdmins = adminService.getOrganizationAdminUsers(pageable);
         return ResponseEntity.ok(ApiResponse.success(
                 PagedDTO.from(orgAdmins, ServletUriComponentsBuilder
                         .fromCurrentRequestUri()
                         .build()
                         .toUriString()),
-                "Organization admin users retrieved successfully"
+                "Organisation admin users retrieved successfully"
         ));
     }
 
@@ -256,7 +256,7 @@ public class AdminController {
     @Operation(
             summary = "Get admin dashboard statistics",
             description = "Retrieves comprehensive statistics for the admin dashboard including user metrics, " +
-                    "organization metrics, content metrics, system performance, and admin-specific data."
+                    "organisation metrics, content metrics, system performance, and admin-specific data."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Dashboard statistics retrieved successfully")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Insufficient privileges - system admin required")
@@ -294,7 +294,7 @@ public class AdminController {
     @Operation(
             summary = "Check if user is admin",
             description = "Checks whether a specific user has any type of administrative privileges. " +
-                    "Returns true if the user has either system admin or organization admin roles."
+                    "Returns true if the user has either system admin or organisation admin roles."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Admin status check completed")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "User not found")
@@ -334,12 +334,12 @@ public class AdminController {
     // ================================
 
     @Operation(
-            summary = "Get pending organization approvals",
-            description = "Retrieves a paginated list of organizations that are awaiting admin verification. " +
+            summary = "Get pending organisation approvals",
+            description = "Retrieves a paginated list of organisations that are awaiting admin verification. " +
                     "Results include organisations where the admin_verified flag is false or not yet set."
     )
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Pending organizations retrieved successfully")
-    @GetMapping("/organizations/pending")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Pending organisations retrieved successfully")
+    @GetMapping("/organisations/pending")
     public ResponseEntity<ApiResponse<PagedDTO<OrganisationDTO>>> getPendingOrganisations(
             @PageableDefault(size = 20) Pageable pageable) {
 
@@ -350,22 +350,22 @@ public class AdminController {
                         .fromCurrentRequestUri()
                         .build()
                         .toUriString()),
-                "Pending organizations retrieved successfully"
+                "Pending organisations retrieved successfully"
         ));
     }
 
     @Operation(
-            summary = "Moderate organization verification",
-            description = "Handles organization approval workflows using a single endpoint. " +
+            summary = "Moderate organisation verification",
+            description = "Handles organisation approval workflows using a single endpoint. " +
                     "Supports approving, rejecting, or revoking admin verification status."
     )
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Organization moderation completed successfully")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Organisation moderation completed successfully")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid moderation action supplied")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "403", description = "Insufficient privileges - system admin required")
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Organization not found")
-    @PostMapping("/organizations/{uuid}/moderate")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Organisation not found")
+    @PostMapping("/organisations/{uuid}/moderate")
     public ResponseEntity<ApiResponse<OrganisationDTO>> moderateOrganisation(
-            @Parameter(description = "UUID of the organization to moderate. Must be an existing organization identifier.",
+            @Parameter(description = "UUID of the organisation to moderate. Must be an existing organisation identifier.",
                     example = "550e8400-e29b-41d4-a716-446655440001", required = true)
             @PathVariable UUID uuid,
             @Parameter(description = "Moderation action to perform",
@@ -375,7 +375,7 @@ public class AdminController {
             @RequestParam(required = false) String reason) {
 
         String normalizedAction = action.toLowerCase();
-        log.info("Admin moderating organization {} with action '{}' and reason: {}", uuid, normalizedAction, reason);
+        log.info("Admin moderating organisation {} with action '{}' and reason: {}", uuid, normalizedAction, reason);
 
         OrganisationDTO organisationDTO;
         String message;
@@ -383,15 +383,15 @@ public class AdminController {
         switch (normalizedAction) {
             case "approve" -> {
                 organisationDTO = organisationService.verifyOrganisation(uuid, reason);
-                message = "Organization approved successfully";
+                message = "Organisation approved successfully";
             }
             case "reject" -> {
                 organisationDTO = organisationService.unverifyOrganisation(uuid, reason);
-                message = "Organization rejected successfully";
+                message = "Organisation rejected successfully";
             }
             case "revoke" -> {
                 organisationDTO = organisationService.unverifyOrganisation(uuid, reason);
-                message = "Organization verification revoked";
+                message = "Organisation verification revoked";
             }
             default -> throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
@@ -403,22 +403,22 @@ public class AdminController {
     }
 
     @Operation(
-            summary = "Check if organization is verified",
-            description = "Checks whether a specific organization has been verified by an admin. " +
-                    "Returns true if the organization has admin verification status."
+            summary = "Check if organisation is verified",
+            description = "Checks whether a specific organisation has been verified by an admin. " +
+                    "Returns true if the organisation has admin verification status."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Verification status check completed")
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Organization not found")
-    @GetMapping("/organizations/{uuid}/verification-status")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Organisation not found")
+    @GetMapping("/organisations/{uuid}/verification-status")
     public ResponseEntity<ApiResponse<Boolean>> isOrganisationVerified(
-            @Parameter(description = "UUID of the organization to check verification status for.",
+            @Parameter(description = "UUID of the organisation to check verification status for.",
                     example = "550e8400-e29b-41d4-a716-446655440001", required = true)
             @PathVariable UUID uuid) {
 
-        log.debug("Checking verification status for organization: {}", uuid);
+        log.debug("Checking verification status for organisation: {}", uuid);
         boolean isVerified = organisationService.isOrganisationVerified(uuid);
         return ResponseEntity.ok(ApiResponse.success(isVerified,
-                isVerified ? "Organization is verified" : "Organization is not verified"));
+                isVerified ? "Organisation is verified" : "Organisation is not verified"));
     }
 
     // ================================

--- a/src/main/java/apps/sarafrika/elimika/tenancy/controller/OrganisationController.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/controller/OrganisationController.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 @RestController
 @RequestMapping("api/v1/organisations")
 @RequiredArgsConstructor
-@Tag(name = "Organisations API", description = "Complete organization management including users and training branches within organizational hierarchy")
+@Tag(name = "Organisations API", description = "Complete organisation management including users and training branches within organisational hierarchy")
 class OrganisationController {
     private final OrganisationService organisationService;
     private final UserService userService;
@@ -173,12 +173,12 @@ class OrganisationController {
     // TRAINING BRANCHES MANAGEMENT
     // ================================
 
-    @Operation(summary = "Create a new training branch within organization")
+    @Operation(summary = "Create a new training branch within organisation")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Training branch created successfully")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid input data")
     @PostMapping("/{uuid}/training-branches")
     public ResponseEntity<ApiResponse<TrainingBranchDTO>> createTrainingBranch(
-            @Parameter(description = "UUID of the organization to create the training branch in. Must be an existing organization.",
+            @Parameter(description = "UUID of the organisation to create the training branch in. Must be an existing organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440001", required = true)
             @PathVariable UUID uuid,
             @Valid @RequestBody TrainingBranchDTO trainingBranchDTO) {
@@ -214,31 +214,31 @@ class OrganisationController {
                 "Training branches retrieved successfully"));
     }
 
-    @Operation(summary = "Get a training branch by UUID within organization")
+    @Operation(summary = "Get a training branch by UUID within organisation")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Training branch retrieved successfully")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Training branch not found")
     @GetMapping("/{uuid}/training-branches/{branchUuid}")
     public ResponseEntity<ApiResponse<TrainingBranchDTO>> getTrainingBranchByUuid(
-            @Parameter(description = "UUID of the organization that owns the training branch. Must be an existing organization.",
+            @Parameter(description = "UUID of the organisation that owns the training branch. Must be an existing organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440001", required = true)
             @PathVariable UUID uuid,
-            @Parameter(description = "UUID of the training branch to retrieve. Must be a branch within the specified organization.",
+            @Parameter(description = "UUID of the training branch to retrieve. Must be a branch within the specified organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440002", required = true)
             @PathVariable UUID branchUuid) {
         TrainingBranchDTO trainingBranch = trainingBranchService.getTrainingBranchByUuid(branchUuid);
         return ResponseEntity.ok(ApiResponse.success(trainingBranch, "Training branch retrieved successfully"));
     }
 
-    @Operation(summary = "Update a training branch by UUID within organization")
+    @Operation(summary = "Update a training branch by UUID within organisation")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Training branch updated successfully")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Training branch not found")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid input data")
     @PutMapping("/{uuid}/training-branches/{branchUuid}")
     public ResponseEntity<ApiResponse<TrainingBranchDTO>> updateTrainingBranch(
-            @Parameter(description = "UUID of the organization that owns the training branch. Must be an existing organization.",
+            @Parameter(description = "UUID of the organisation that owns the training branch. Must be an existing organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440001", required = true)
             @PathVariable UUID uuid,
-            @Parameter(description = "UUID of the training branch to update. Must be a branch within the specified organization.",
+            @Parameter(description = "UUID of the training branch to update. Must be a branch within the specified organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440002", required = true)
             @PathVariable UUID branchUuid,
             @Valid @RequestBody TrainingBranchDTO trainingBranchDTO) {
@@ -246,12 +246,12 @@ class OrganisationController {
         return ResponseEntity.ok(ApiResponse.success(updated, "Training branch updated successfully"));
     }
 
-    @Operation(summary = "Delete a training branch by UUID within organization")
+    @Operation(summary = "Delete a training branch by UUID within organisation")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Training branch deleted successfully")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Training branch not found")
     @DeleteMapping("/{uuid}/training-branches/{branchUuid}")
     public ResponseEntity<ApiResponse<Void>> deleteTrainingBranch(
-            @Parameter(description = "UUID of the organization that owns the training branch. Must be an existing organization.",
+            @Parameter(description = "UUID of the organisation that owns the training branch. Must be an existing organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440001", required = true)
             @PathVariable UUID uuid,
             @Parameter(description = "UUID of the training branch to delete. This will soft-delete the branch and remove all user assignments.",
@@ -263,17 +263,17 @@ class OrganisationController {
 
     @Operation(
             summary = "Get users assigned to training branch",
-            description = "Retrieves all users that are assigned to a specific training branch within the organization. " +
+            description = "Retrieves all users that are assigned to a specific training branch within the organisation. " +
                     "This includes users with any role/domain within the branch."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Branch users retrieved successfully")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Training branch not found")
     @GetMapping("/{uuid}/training-branches/{branchUuid}/users")
     public ResponseEntity<ApiResponse<List<UserDTO>>> getBranchUsers(
-            @Parameter(description = "UUID of the organization that owns the training branch. Must be an existing organization.",
+            @Parameter(description = "UUID of the organisation that owns the training branch. Must be an existing organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440001", required = true)
             @PathVariable UUID uuid,
-            @Parameter(description = "UUID of the training branch to get users for. Must be a branch within the specified organization.",
+            @Parameter(description = "UUID of the training branch to get users for. Must be a branch within the specified organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440002", required = true)
             @PathVariable UUID branchUuid) {
         List<UserDTO> users = trainingBranchService.getBranchUsers(branchUuid);
@@ -290,10 +290,10 @@ class OrganisationController {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid domain name")
     @GetMapping("/{uuid}/training-branches/{branchUuid}/users/domain/{domainName}")
     public ResponseEntity<ApiResponse<List<UserDTO>>> getBranchUsersByDomain(
-            @Parameter(description = "UUID of the organization that owns the training branch. Must be an existing organization.",
+            @Parameter(description = "UUID of the organisation that owns the training branch. Must be an existing organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440001", required = true)
             @PathVariable UUID uuid,
-            @Parameter(description = "UUID of the training branch to get users for. Must be a branch within the specified organization.",
+            @Parameter(description = "UUID of the training branch to get users for. Must be a branch within the specified organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440002", required = true)
             @PathVariable UUID branchUuid,
             @Parameter(description = "Domain name to filter users by. Valid values: 'student', 'instructor', 'admin', 'organisation_user'",
@@ -306,18 +306,18 @@ class OrganisationController {
     @Operation(
             summary = "Assign user to training branch",
             description = "Assigns a user to a specific training branch with a defined role. " +
-                    "If the user is not already in the parent organization, creates organization membership first. " +
-                    "If the user is already in the organization, updates their branch assignment."
+                    "If the user is not already in the parent organisation, creates organisation membership first. " +
+                    "If the user is already in the organisation, updates their branch assignment."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "User assigned to branch successfully")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Training branch or user not found")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid domain name")
     @PostMapping("/{uuid}/training-branches/{branchUuid}/users/{userUuid}")
     public ResponseEntity<ApiResponse<Void>> assignUserToBranch(
-            @Parameter(description = "UUID of the organization that owns the training branch. Must be an existing organization.",
+            @Parameter(description = "UUID of the organisation that owns the training branch. Must be an existing organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440001", required = true)
             @PathVariable UUID uuid,
-            @Parameter(description = "UUID of the training branch to assign the user to. Must be a branch within the specified organization.",
+            @Parameter(description = "UUID of the training branch to assign the user to. Must be a branch within the specified organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440002", required = true)
             @PathVariable UUID branchUuid,
             @Parameter(description = "UUID of the user to assign to the training branch. Must be an existing user.",
@@ -333,16 +333,16 @@ class OrganisationController {
     @Operation(
             summary = "Remove user from training branch",
             description = "Removes a user from a training branch. " +
-                    "The user remains in the parent organization but loses branch-specific assignment."
+                    "The user remains in the parent organisation but loses branch-specific assignment."
     )
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "User removed from branch successfully")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Training branch or user not found, or user not assigned to branch")
     @DeleteMapping("/{uuid}/training-branches/{branchUuid}/users/{userUuid}")
     public ResponseEntity<ApiResponse<Void>> removeUserFromBranch(
-            @Parameter(description = "UUID of the organization that owns the training branch. Must be an existing organization.",
+            @Parameter(description = "UUID of the organisation that owns the training branch. Must be an existing organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440001", required = true)
             @PathVariable UUID uuid,
-            @Parameter(description = "UUID of the training branch to remove the user from. Must be a branch within the specified organization.",
+            @Parameter(description = "UUID of the training branch to remove the user from. Must be a branch within the specified organisation.",
                     example = "550e8400-e29b-41d4-a716-446655440002", required = true)
             @PathVariable UUID branchUuid,
             @Parameter(description = "UUID of the user to remove from the training branch. Must be currently assigned to the branch.",

--- a/src/main/java/apps/sarafrika/elimika/tenancy/controller/UserController.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/controller/UserController.java
@@ -150,7 +150,7 @@ class UserController {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "User not found")
     @DeleteMapping("/{uuid}")
     public ResponseEntity<ApiResponse<Void>> deleteUser(
-            @Parameter(description = "UUID of the user to delete. This will remove the user and all their organization relationships.",
+            @Parameter(description = "UUID of the user to delete. This will remove the user and all their organisation relationships.",
                     example = "550e8400-e29b-41d4-a716-446655440001", required = true)
             @PathVariable UUID uuid) {
         userService.deleteUser(uuid);

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/AdminDashboardStatsDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/AdminDashboardStatsDTO.java
@@ -31,8 +31,8 @@ public record AdminDashboardStatsDTO(
     @JsonProperty("user_metrics")
     UserMetrics userMetrics,
 
-    @Schema(description = "Organization-related metrics")
-    @JsonProperty("organization_metrics")
+    @Schema(description = "Organisation-related metrics")
+    @JsonProperty("organisation_metrics")
     OrganizationMetrics organizationMetrics,
 
     @Schema(description = "Content-related metrics")
@@ -87,15 +87,15 @@ public record AdminDashboardStatsDTO(
         long suspendedAccounts
     ) {}
 
-    @Schema(description = "Organization metrics for dashboard")
+    @Schema(description = "Organisation metrics for dashboard")
     public record OrganizationMetrics(
-        @JsonProperty("total_organizations")
+        @JsonProperty("total_organisations")
         long totalOrganizations,
         @JsonProperty("pending_approvals")
         long pendingApprovals,
-        @JsonProperty("active_organizations")
+        @JsonProperty("active_organisations")
         long activeOrganizations,
-        @JsonProperty("suspended_organizations")
+        @JsonProperty("suspended_organisations")
         long suspendedOrganizations
     ) {}
 
@@ -133,7 +133,7 @@ public record AdminDashboardStatsDTO(
         long adminActionsToday,
         @JsonProperty("system_admins")
         long systemAdmins,
-        @JsonProperty("organization_admins")
+        @JsonProperty("organisation_admins")
         long organizationAdmins
     ) {}
 

--- a/src/main/java/apps/sarafrika/elimika/tenancy/services/impl/AdminServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/services/impl/AdminServiceImpl.java
@@ -610,7 +610,7 @@ public class AdminServiceImpl implements AdminService {
         String method = log.getHttpMethod() == null ? "" : log.getHttpMethod().toUpperCase();
         String uri = log.getRequestUri() == null ? "" : log.getRequestUri();
 
-        if (uri.contains("/organizations") && uri.contains("/moderate")) {
+        if (uri.contains("/organisations") && uri.contains("/moderate")) {
             String action = extractQueryParam(log.getQueryString(), "action");
             return switch (action != null ? action.toLowerCase() : "moderate") {
                 case "approve" -> "Approved organisation";

--- a/src/test/java/apps/sarafrika/elimika/course/controller/CourseControllerTest.java
+++ b/src/test/java/apps/sarafrika/elimika/course/controller/CourseControllerTest.java
@@ -1,0 +1,164 @@
+package apps.sarafrika.elimika.course.controller;
+
+import apps.sarafrika.elimika.course.dto.LessonContentDTO;
+import apps.sarafrika.elimika.course.internal.LessonMediaValidationService;
+import apps.sarafrika.elimika.course.service.*;
+import apps.sarafrika.elimika.shared.dto.ApiResponse;
+import apps.sarafrika.elimika.shared.storage.config.StorageProperties;
+import apps.sarafrika.elimika.shared.storage.service.StorageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class CourseControllerTest {
+
+    @Mock
+    private CourseService courseService;
+    @Mock
+    private LessonService lessonService;
+    @Mock
+    private LessonContentService lessonContentService;
+    @Mock
+    private CourseAssessmentService courseAssessmentService;
+    @Mock
+    private CourseRequirementService courseRequirementService;
+    @Mock
+    private CourseTrainingRequirementService courseTrainingRequirementService;
+    @Mock
+    private CourseTrainingApplicationService courseTrainingApplicationService;
+    @Mock
+    private CourseEnrollmentService courseEnrollmentService;
+    @Mock
+    private CourseCategoryService courseCategoryService;
+    @Mock
+    private CourseReviewService courseReviewService;
+    @Mock
+    private StorageService storageService;
+    @Mock
+    private LessonMediaValidationService lessonMediaValidationService;
+
+    private StorageProperties storageProperties;
+    private CourseController courseController;
+
+    @BeforeEach
+    void setUp() {
+        storageProperties = new StorageProperties();
+        storageProperties.setBaseUrl("https://api.elimika.sarafrika.com");
+        StorageProperties.Folders folders = new StorageProperties.Folders();
+        folders.setCourseMaterials("course_materials");
+        folders.setCourseThumbnails("course_thumbnails");
+        storageProperties.setFolders(folders);
+
+        courseController = new CourseController(
+                courseService,
+                lessonService,
+                lessonContentService,
+                courseAssessmentService,
+                courseRequirementService,
+                courseTrainingRequirementService,
+                courseTrainingApplicationService,
+                courseEnrollmentService,
+                courseCategoryService,
+                courseReviewService,
+                storageService,
+                storageProperties,
+                lessonMediaValidationService
+        );
+    }
+
+    @Test
+    void uploadLessonMediaBuildsPreviewUrlThroughContentMediaEndpoint() {
+        UUID courseUuid = UUID.randomUUID();
+        UUID lessonUuid = UUID.randomUUID();
+        UUID contentTypeUuid = UUID.randomUUID();
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "intro.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "pdf".getBytes()
+        );
+        String storedPath = "course_materials/" + courseUuid + "/lessons/" + lessonUuid + "/intro.pdf";
+
+        doNothing().when(lessonMediaValidationService).validateForLessonContent(file);
+        when(storageService.store(file, "course_materials/" + courseUuid + "/lessons/" + lessonUuid))
+                .thenReturn(storedPath);
+        when(storageService.getContentType(storedPath)).thenReturn(MediaType.APPLICATION_PDF_VALUE);
+        when(lessonContentService.createLessonContent(any(LessonContentDTO.class)))
+                .thenAnswer(invocation -> {
+                    LessonContentDTO request = invocation.getArgument(0);
+                    return new LessonContentDTO(
+                            UUID.randomUUID(),
+                            request.lessonUuid(),
+                            request.contentTypeUuid(),
+                            request.title(),
+                            request.description(),
+                            request.contentText(),
+                            request.fileUrl(),
+                            request.fileSizeBytes(),
+                            request.mimeType(),
+                            1,
+                            request.isRequired(),
+                            null,
+                            null,
+                            null,
+                            null
+                    );
+                });
+
+        ResponseEntity<ApiResponse<LessonContentDTO>> response = courseController.uploadLessonMedia(
+                courseUuid,
+                lessonUuid,
+                file,
+                contentTypeUuid,
+                "Lesson PDF",
+                "Previewable handout",
+                true
+        );
+
+        assertEquals(HttpStatus.CREATED, response.getStatusCode());
+        assertNotNull(response.getBody());
+        assertNotNull(response.getBody().data());
+        assertEquals(
+                "https://api.elimika.sarafrika.com/api/v1/courses/content-media/" + storedPath,
+                response.getBody().data().fileUrl()
+        );
+        assertEquals(MediaType.APPLICATION_PDF_VALUE, response.getBody().data().mimeType());
+    }
+
+    @Test
+    void getCourseContentMediaServesStoredLessonFileInline() {
+        String storedPath = "course_materials/course-uuid/lessons/lesson-uuid/video.mp4";
+        ByteArrayResource resource = new ByteArrayResource("video".getBytes());
+
+        when(storageService.load(storedPath)).thenReturn(resource);
+        when(storageService.getContentType(storedPath)).thenReturn("video/mp4");
+
+        ResponseEntity<org.springframework.core.io.Resource> response =
+                courseController.getCourseContentMedia(storedPath);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(MediaType.parseMediaType("video/mp4"), response.getHeaders().getContentType());
+        assertEquals(
+                "inline; filename=\"video.mp4\"",
+                response.getHeaders().getFirst(HttpHeaders.CONTENT_DISPOSITION)
+        );
+        assertSame(resource, response.getBody());
+    }
+}


### PR DESCRIPTION
## Summary
Standardise public API spelling from  to  across renamed tenancy endpoints and API-facing JSON properties.

## Changes
- Renamed admin moderation and verification endpoints from  to 
- Renamed the admin users endpoint from  to 
- Updated API-facing DTO JSON properties such as , , , and 
- Aligned OpenAPI descriptions and controller text with  spelling
- Updated request-audit summary detection to recognise the renamed moderation route

## Tests
- Starting a Gradle Daemon (subsequent builds will be faster)
> Task :compileJava

BUILD SUCCESSFUL in 19s
1 actionable task: 1 executed
- Result: failed in sandbox with 

## Configuration Or Secret Impacts
- No configuration or secret changes