### PR TITLE
fix: align document verification status with workflow status

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/coursecreator/dto/CourseCreatorDocumentDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/coursecreator/dto/CourseCreatorDocumentDTO.java
@@ -168,7 +168,10 @@ public record CourseCreatorDocumentDTO(
             accessMode = Schema.AccessMode.READ_ONLY
     )
     public boolean isPendingVerification() {
-        return isVerified == null || !isVerified;
+        if (status != null) {
+            return status == DocumentStatus.PENDING;
+        }
+        return !Boolean.TRUE.equals(isVerified);
     }
 
     @JsonProperty(value = "has_expiry_date", access = JsonProperty.Access.READ_ONLY)
@@ -185,13 +188,22 @@ public record CourseCreatorDocumentDTO(
     @Schema(
             description = "**[READ-ONLY]** Human-readable verification status of the document.",
             example = "VERIFIED",
-            allowableValues = {"VERIFIED", "PENDING", "REJECTED"},
+            allowableValues = {"VERIFIED", "PENDING", "REJECTED", "EXPIRED"},
             accessMode = Schema.AccessMode.READ_ONLY
     )
     public String getVerificationStatus() {
-        if (isVerified == null) {
+        if (status == DocumentStatus.APPROVED) {
+            return "VERIFIED";
+        }
+        if (status == DocumentStatus.REJECTED) {
+            return "REJECTED";
+        }
+        if (status == DocumentStatus.EXPIRED) {
+            return "EXPIRED";
+        }
+        if (status == DocumentStatus.PENDING) {
             return "PENDING";
         }
-        return isVerified ? "VERIFIED" : "REJECTED";
+        return Boolean.TRUE.equals(isVerified) ? "VERIFIED" : "PENDING";
     }
 }

--- a/src/main/java/apps/sarafrika/elimika/instructor/dto/InstructorDocumentDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/instructor/dto/InstructorDocumentDTO.java
@@ -392,7 +392,10 @@ public record InstructorDocumentDTO(
             accessMode = Schema.AccessMode.READ_ONLY
     )
     public boolean isPendingVerification() {
-        return isVerified == null || !isVerified;
+        if (status != null) {
+            return status == DocumentStatus.PENDING;
+        }
+        return !Boolean.TRUE.equals(isVerified);
     }
 
     /**
@@ -419,13 +422,22 @@ public record InstructorDocumentDTO(
     @Schema(
             description = "**[READ-ONLY]** Human-readable verification status of the document.",
             example = "VERIFIED",
-            allowableValues = {"VERIFIED", "PENDING", "REJECTED"},
+            allowableValues = {"VERIFIED", "PENDING", "REJECTED", "EXPIRED"},
             accessMode = Schema.AccessMode.READ_ONLY
     )
     public String getVerificationStatus() {
-        if (isVerified == null) {
+        if (status == DocumentStatus.APPROVED) {
+            return "VERIFIED";
+        }
+        if (status == DocumentStatus.REJECTED) {
+            return "REJECTED";
+        }
+        if (status == DocumentStatus.EXPIRED) {
+            return "EXPIRED";
+        }
+        if (status == DocumentStatus.PENDING) {
             return "PENDING";
         }
-        return isVerified ? "VERIFIED" : "REJECTED";
+        return Boolean.TRUE.equals(isVerified) ? "VERIFIED" : "PENDING";
     }
 }

--- a/src/test/java/apps/sarafrika/elimika/coursecreator/dto/CourseCreatorDocumentDTOTest.java
+++ b/src/test/java/apps/sarafrika/elimika/coursecreator/dto/CourseCreatorDocumentDTOTest.java
@@ -1,0 +1,81 @@
+package apps.sarafrika.elimika.coursecreator.dto;
+
+import apps.sarafrika.elimika.shared.utils.enums.DocumentStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CourseCreatorDocumentDTOTest {
+
+    @Test
+    void pendingStatusReportsPendingVerification() {
+        CourseCreatorDocumentDTO document = document(DocumentStatus.PENDING, false);
+
+        assertThat(document.getVerificationStatus()).isEqualTo("PENDING");
+        assertThat(document.isPendingVerification()).isTrue();
+    }
+
+    @Test
+    void approvedStatusReportsVerified() {
+        CourseCreatorDocumentDTO document = document(DocumentStatus.APPROVED, true);
+
+        assertThat(document.getVerificationStatus()).isEqualTo("VERIFIED");
+        assertThat(document.isPendingVerification()).isFalse();
+    }
+
+    @Test
+    void rejectedStatusReportsRejected() {
+        CourseCreatorDocumentDTO document = document(DocumentStatus.REJECTED, false);
+
+        assertThat(document.getVerificationStatus()).isEqualTo("REJECTED");
+        assertThat(document.isPendingVerification()).isFalse();
+    }
+
+    @Test
+    void expiredStatusReportsExpired() {
+        CourseCreatorDocumentDTO document = document(DocumentStatus.EXPIRED, false);
+
+        assertThat(document.getVerificationStatus()).isEqualTo("EXPIRED");
+        assertThat(document.isPendingVerification()).isFalse();
+    }
+
+    @Test
+    void nullStatusDoesNotTreatUnverifiedAsRejected() {
+        CourseCreatorDocumentDTO document = document(null, false);
+
+        assertThat(document.getVerificationStatus()).isEqualTo("PENDING");
+        assertThat(document.isPendingVerification()).isTrue();
+    }
+
+    private CourseCreatorDocumentDTO document(DocumentStatus status, Boolean isVerified) {
+        return new CourseCreatorDocumentDTO(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null,
+                null,
+                null,
+                "certificate.pdf",
+                "profile_documents/course-creators/creator/certificate.pdf",
+                "profile_documents/course-creators/creator/certificate.pdf",
+                1024L,
+                "application/pdf",
+                null,
+                "Certificate",
+                null,
+                null,
+                isVerified,
+                null,
+                null,
+                null,
+                status,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/src/test/java/apps/sarafrika/elimika/instructor/dto/InstructorDocumentDTOTest.java
+++ b/src/test/java/apps/sarafrika/elimika/instructor/dto/InstructorDocumentDTOTest.java
@@ -1,0 +1,81 @@
+package apps.sarafrika.elimika.instructor.dto;
+
+import apps.sarafrika.elimika.shared.utils.enums.DocumentStatus;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InstructorDocumentDTOTest {
+
+    @Test
+    void pendingStatusReportsPendingVerification() {
+        InstructorDocumentDTO document = document(DocumentStatus.PENDING, false);
+
+        assertThat(document.getVerificationStatus()).isEqualTo("PENDING");
+        assertThat(document.isPendingVerification()).isTrue();
+    }
+
+    @Test
+    void approvedStatusReportsVerified() {
+        InstructorDocumentDTO document = document(DocumentStatus.APPROVED, true);
+
+        assertThat(document.getVerificationStatus()).isEqualTo("VERIFIED");
+        assertThat(document.isPendingVerification()).isFalse();
+    }
+
+    @Test
+    void rejectedStatusReportsRejected() {
+        InstructorDocumentDTO document = document(DocumentStatus.REJECTED, false);
+
+        assertThat(document.getVerificationStatus()).isEqualTo("REJECTED");
+        assertThat(document.isPendingVerification()).isFalse();
+    }
+
+    @Test
+    void expiredStatusReportsExpired() {
+        InstructorDocumentDTO document = document(DocumentStatus.EXPIRED, false);
+
+        assertThat(document.getVerificationStatus()).isEqualTo("EXPIRED");
+        assertThat(document.isPendingVerification()).isFalse();
+    }
+
+    @Test
+    void nullStatusDoesNotTreatUnverifiedAsRejected() {
+        InstructorDocumentDTO document = document(null, false);
+
+        assertThat(document.getVerificationStatus()).isEqualTo("PENDING");
+        assertThat(document.isPendingVerification()).isTrue();
+    }
+
+    private InstructorDocumentDTO document(DocumentStatus status, Boolean isVerified) {
+        return new InstructorDocumentDTO(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null,
+                null,
+                null,
+                "certificate.pdf",
+                "profile_documents/instructors/instructor/certificate.pdf",
+                "profile_documents/instructors/instructor/certificate.pdf",
+                1024L,
+                "application/pdf",
+                null,
+                "Certificate",
+                null,
+                null,
+                isVerified,
+                null,
+                null,
+                null,
+                status,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Align derived document verification labels with the persisted workflow status.
- Prevent newly uploaded pending documents from reporting verification_status as REJECTED.

## Changes
- Derive course creator and instructor document verification_status from DocumentStatus first.
- Treat only explicit REJECTED workflow status as rejected.
- Add EXPIRED as a documented derived verification status.
- Add DTO unit coverage for pending, approved, rejected, expired, and null-status fallback states.

## Tests
- /usr/bin/env JAVA_HOME=/home/willy/.jdks/temurin-21.0.11 ./gradlew test

## Configuration/Secret Impacts
- No configuration or secret changes.