### PR TITLE
feat: add program review rating API

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/course/dto/ProgramRatingSummaryDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/ProgramRatingSummaryDTO.java
@@ -1,0 +1,43 @@
+package apps.sarafrika.elimika.course.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+@Schema(
+        name = "ProgramRatingSummary",
+        description = "Aggregate review metrics for a training program.",
+        example = """
+        {
+          "program_uuid": "640d0a57-76cc-46f2-ad46-72f5635d973a",
+          "average_rating": 4.7,
+          "review_count": 12
+        }
+        """
+)
+public record ProgramRatingSummaryDTO(
+
+        @Schema(
+                description = "UUID of the training program.",
+                example = "640d0a57-76cc-46f2-ad46-72f5635d973a"
+        )
+        @JsonProperty("program_uuid")
+        UUID programUuid,
+
+        @Schema(
+                description = "Average overall rating across all program reviews (1-5). Null when there are no reviews.",
+                example = "4.7",
+                nullable = true
+        )
+        @JsonProperty("average_rating")
+        Double averageRating,
+
+        @Schema(
+                description = "Total number of reviews for this program.",
+                example = "12"
+        )
+        @JsonProperty("review_count")
+        Long reviewCount
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/course/dto/ProgramReviewDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/ProgramReviewDTO.java
@@ -1,0 +1,123 @@
+package apps.sarafrika.elimika.course.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(
+        name = "ProgramReview",
+        description = "Student review and rating for a training program.",
+        example = """
+        {
+          "uuid": "d41707bc-e652-4ea4-8db0-ea9c85ff7d5c",
+          "program_uuid": "640d0a57-76cc-46f2-ad46-72f5635d973a",
+          "student_uuid": "4d91801f-0d0f-4078-9b70-7f68f7531c8a",
+          "rating": 5,
+          "headline": "Excellent learning pathway",
+          "comments": "The program sequence was practical and easy to follow.",
+          "is_anonymous": false,
+          "created_date": "2026-06-11T12:33:00",
+          "created_by": "student@example.com",
+          "updated_date": "2026-06-11T12:33:00",
+          "updated_by": "student@example.com"
+        }
+        """
+)
+public record ProgramReviewDTO(
+
+        @Schema(
+                description = "**[READ-ONLY]** Unique identifier for the review.",
+                example = "d41707bc-e652-4ea4-8db0-ea9c85ff7d5c",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID uuid,
+
+        @Schema(
+                description = "**[READ-ONLY]** Training program being reviewed.",
+                example = "640d0a57-76cc-46f2-ad46-72f5635d973a",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "program_uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID programUuid,
+
+        @Schema(
+                description = "**[READ-ONLY]** Student who left the review. Null for anonymous public responses.",
+                example = "4d91801f-0d0f-4078-9b70-7f68f7531c8a",
+                nullable = true,
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "student_uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID studentUuid,
+
+        @Schema(
+                description = "Overall rating for the program (1-5).",
+                example = "5",
+                minimum = "1",
+                maximum = "5"
+        )
+        @JsonProperty("rating")
+        Integer rating,
+
+        @Schema(
+                description = "Optional short headline for the review.",
+                example = "Excellent learning pathway",
+                maxLength = 255
+        )
+        @JsonProperty("headline")
+        String headline,
+
+        @Schema(
+                description = "Detailed feedback from the student.",
+                example = "The program sequence was practical and easy to follow.",
+                maxLength = 5000
+        )
+        @JsonProperty("comments")
+        String comments,
+
+        @Schema(
+                description = "Whether the review should be shown anonymously in public views.",
+                example = "false"
+        )
+        @JsonProperty("is_anonymous")
+        Boolean isAnonymous,
+
+        @Schema(
+                description = "**[READ-ONLY]** Timestamp when the review was created.",
+                example = "2026-06-11T12:33:00",
+                format = "date-time",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "created_date", access = JsonProperty.Access.READ_ONLY)
+        LocalDateTime createdDate,
+
+        @Schema(
+                description = "**[READ-ONLY]** Created by identifier. Null for anonymous public responses.",
+                example = "student@example.com",
+                nullable = true,
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "created_by", access = JsonProperty.Access.READ_ONLY)
+        String createdBy,
+
+        @Schema(
+                description = "**[READ-ONLY]** Timestamp when the review was last updated.",
+                example = "2026-06-11T12:33:00",
+                format = "date-time",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "updated_date", access = JsonProperty.Access.READ_ONLY)
+        LocalDateTime updatedDate,
+
+        @Schema(
+                description = "**[READ-ONLY]** Updated by identifier. Null for anonymous public responses.",
+                example = "student@example.com",
+                nullable = true,
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "updated_by", access = JsonProperty.Access.READ_ONLY)
+        String updatedBy
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/course/dto/ProgramReviewRequest.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/ProgramReviewRequest.java
@@ -1,0 +1,74 @@
+package apps.sarafrika.elimika.course.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+@Schema(
+        name = "ProgramReviewRequest",
+        description = "Payload for submitting or updating a student review for a training program.",
+        example = """
+        {
+          "student_uuid": "4d91801f-0d0f-4078-9b70-7f68f7531c8a",
+          "rating": 5,
+          "headline": "Excellent learning pathway",
+          "comments": "The program sequence was practical and easy to follow.",
+          "is_anonymous": false
+        }
+        """
+)
+public record ProgramReviewRequest(
+
+        @Schema(
+                description = "**[REQUIRED]** Student leaving the review.",
+                example = "4d91801f-0d0f-4078-9b70-7f68f7531c8a",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotNull(message = "Student UUID is required")
+        @JsonProperty("student_uuid")
+        UUID studentUuid,
+
+        @Schema(
+                description = "**[REQUIRED]** Overall rating for the program (1-5).",
+                example = "5",
+                minimum = "1",
+                maximum = "5",
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @NotNull(message = "Rating is required")
+        @Min(value = 1, message = "Rating must be at least 1")
+        @Max(value = 5, message = "Rating must be at most 5")
+        @JsonProperty("rating")
+        Integer rating,
+
+        @Schema(
+                description = "Optional short headline for the review.",
+                example = "Excellent learning pathway",
+                maxLength = 255
+        )
+        @Size(max = 255, message = "Headline must not exceed 255 characters")
+        @JsonProperty("headline")
+        String headline,
+
+        @Schema(
+                description = "Detailed feedback from the student.",
+                example = "The program sequence was practical and easy to follow.",
+                maxLength = 5000
+        )
+        @Size(max = 5000, message = "Comments must not exceed 5000 characters")
+        @JsonProperty("comments")
+        String comments,
+
+        @Schema(
+                description = "Whether the review should be shown anonymously in public views.",
+                example = "false"
+        )
+        @JsonProperty("is_anonymous")
+        Boolean isAnonymous
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/course/factory/ProgramReviewFactory.java
+++ b/src/main/java/apps/sarafrika/elimika/course/factory/ProgramReviewFactory.java
@@ -1,0 +1,29 @@
+package apps.sarafrika.elimika.course.factory;
+
+import apps.sarafrika.elimika.course.dto.ProgramReviewDTO;
+import apps.sarafrika.elimika.course.model.ProgramReview;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ProgramReviewFactory {
+
+    public static ProgramReviewDTO toDTO(ProgramReview entity) {
+        if (entity == null) {
+            return null;
+        }
+        return new ProgramReviewDTO(
+                entity.getUuid(),
+                entity.getProgramUuid(),
+                entity.getStudentUuid(),
+                entity.getRating(),
+                entity.getHeadline(),
+                entity.getComments(),
+                entity.getIsAnonymous(),
+                entity.getCreatedDate(),
+                entity.getCreatedBy(),
+                entity.getLastModifiedDate(),
+                entity.getLastModifiedBy()
+        );
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/course/model/ProgramReview.java
+++ b/src/main/java/apps/sarafrika/elimika/course/model/ProgramReview.java
@@ -1,0 +1,39 @@
+package apps.sarafrika.elimika.course.model;
+
+import apps.sarafrika.elimika.shared.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "program_reviews")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ProgramReview extends BaseEntity {
+
+    @Column(name = "program_uuid")
+    private UUID programUuid;
+
+    @Column(name = "student_uuid")
+    private UUID studentUuid;
+
+    @Column(name = "rating")
+    private Integer rating;
+
+    @Column(name = "headline")
+    private String headline;
+
+    @Column(name = "comments")
+    private String comments;
+
+    @Column(name = "is_anonymous")
+    private Boolean isAnonymous;
+}

--- a/src/main/java/apps/sarafrika/elimika/course/repository/ProgramEnrollmentRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/course/repository/ProgramEnrollmentRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -23,6 +24,11 @@ public interface ProgramEnrollmentRepository extends JpaRepository<ProgramEnroll
     long countByProgramUuidAndStatus(UUID programUuid, EnrollmentStatus status);
 
     boolean existsByStudentUuidAndProgramUuidAndStatus(UUID studentUuid, UUID programUuid, EnrollmentStatus status);
+
+    boolean existsByStudentUuidAndProgramUuidAndStatusIn(
+            UUID studentUuid,
+            UUID programUuid,
+            Collection<EnrollmentStatus> statuses);
 
     boolean existsByUuid(UUID uuid);
 

--- a/src/main/java/apps/sarafrika/elimika/course/repository/ProgramReviewRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/course/repository/ProgramReviewRepository.java
@@ -1,0 +1,25 @@
+package apps.sarafrika.elimika.course.repository;
+
+import apps.sarafrika.elimika.course.model.ProgramReview;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ProgramReviewRepository extends JpaRepository<ProgramReview, Long> {
+
+    Page<ProgramReview> findByProgramUuid(UUID programUuid, Pageable pageable);
+
+    Optional<ProgramReview> findByProgramUuidAndStudentUuid(UUID programUuid, UUID studentUuid);
+
+    long countByProgramUuid(UUID programUuid);
+
+    @Query("SELECT AVG(r.rating) FROM ProgramReview r WHERE r.programUuid = :programUuid")
+    Double findAverageRatingForProgram(@Param("programUuid") UUID programUuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/course/service/ProgramReviewService.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/ProgramReviewService.java
@@ -1,0 +1,18 @@
+package apps.sarafrika.elimika.course.service;
+
+import apps.sarafrika.elimika.course.dto.ProgramRatingSummaryDTO;
+import apps.sarafrika.elimika.course.dto.ProgramReviewDTO;
+import apps.sarafrika.elimika.course.dto.ProgramReviewRequest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.UUID;
+
+public interface ProgramReviewService {
+
+    ProgramReviewDTO saveProgramReview(UUID programUuid, ProgramReviewRequest reviewRequest);
+
+    Page<ProgramReviewDTO> getReviewsForProgram(UUID programUuid, Pageable pageable);
+
+    ProgramRatingSummaryDTO getRatingSummary(UUID programUuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/course/service/impl/ProgramReviewServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/impl/ProgramReviewServiceImpl.java
@@ -1,0 +1,114 @@
+package apps.sarafrika.elimika.course.service.impl;
+
+import apps.sarafrika.elimika.course.dto.ProgramRatingSummaryDTO;
+import apps.sarafrika.elimika.course.dto.ProgramReviewDTO;
+import apps.sarafrika.elimika.course.dto.ProgramReviewRequest;
+import apps.sarafrika.elimika.course.factory.ProgramReviewFactory;
+import apps.sarafrika.elimika.course.model.ProgramReview;
+import apps.sarafrika.elimika.course.repository.ProgramEnrollmentRepository;
+import apps.sarafrika.elimika.course.repository.ProgramReviewRepository;
+import apps.sarafrika.elimika.course.repository.TrainingProgramRepository;
+import apps.sarafrika.elimika.course.service.ProgramReviewService;
+import apps.sarafrika.elimika.course.util.enums.EnrollmentStatus;
+import apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProgramReviewServiceImpl implements ProgramReviewService {
+
+    private static final Set<EnrollmentStatus> REVIEW_ELIGIBLE_STATUSES = Set.of(
+            EnrollmentStatus.ACTIVE,
+            EnrollmentStatus.COMPLETED
+    );
+
+    private final ProgramReviewRepository programReviewRepository;
+    private final ProgramEnrollmentRepository programEnrollmentRepository;
+    private final TrainingProgramRepository trainingProgramRepository;
+
+    @Override
+    public ProgramReviewDTO saveProgramReview(UUID programUuid, ProgramReviewRequest reviewRequest) {
+        enforceProgramExists(programUuid);
+
+        UUID studentUuid = reviewRequest.studentUuid();
+        if (!programEnrollmentRepository.existsByStudentUuidAndProgramUuidAndStatusIn(
+                studentUuid, programUuid, REVIEW_ELIGIBLE_STATUSES)) {
+            throw new IllegalStateException("Student must have an active or completed program enrollment to leave a review.");
+        }
+
+        ProgramReview review = programReviewRepository.findByProgramUuidAndStudentUuid(programUuid, studentUuid)
+                .orElseGet(ProgramReview::new);
+
+        if (review.getProgramUuid() == null) {
+            review.setProgramUuid(programUuid);
+        }
+        if (review.getStudentUuid() == null) {
+            review.setStudentUuid(studentUuid);
+        }
+
+        review.setRating(reviewRequest.rating());
+        review.setHeadline(reviewRequest.headline());
+        review.setComments(reviewRequest.comments());
+        review.setIsAnonymous(Boolean.TRUE.equals(reviewRequest.isAnonymous()));
+
+        ProgramReview saved = programReviewRepository.save(review);
+        return toPublicDTO(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ProgramReviewDTO> getReviewsForProgram(UUID programUuid, Pageable pageable) {
+        enforceProgramExists(programUuid);
+        return programReviewRepository.findByProgramUuid(programUuid, pageable)
+                .map(this::toPublicDTO);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ProgramRatingSummaryDTO getRatingSummary(UUID programUuid) {
+        enforceProgramExists(programUuid);
+        long reviewCount = programReviewRepository.countByProgramUuid(programUuid);
+        Double averageRating = reviewCount == 0 ? null : programReviewRepository.findAverageRatingForProgram(programUuid);
+        return new ProgramRatingSummaryDTO(programUuid, averageRating, reviewCount);
+    }
+
+    private void enforceProgramExists(UUID programUuid) {
+        if (programUuid == null) {
+            throw new IllegalArgumentException("Program UUID is required");
+        }
+        if (!trainingProgramRepository.existsByUuid(programUuid)) {
+            throw new ResourceNotFoundException("Training program with UUID " + programUuid + " not found");
+        }
+    }
+
+    private ProgramReviewDTO toPublicDTO(ProgramReview review) {
+        ProgramReviewDTO dto = ProgramReviewFactory.toDTO(review);
+        if (dto == null) {
+            return null;
+        }
+        if (!Boolean.TRUE.equals(dto.isAnonymous())) {
+            return dto;
+        }
+        return new ProgramReviewDTO(
+                dto.uuid(),
+                dto.programUuid(),
+                null,
+                dto.rating(),
+                dto.headline(),
+                dto.comments(),
+                dto.isAnonymous(),
+                dto.createdDate(),
+                null,
+                dto.updatedDate(),
+                null
+        );
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/shared/controller/TrainingProgramController.java
+++ b/src/main/java/apps/sarafrika/elimika/shared/controller/TrainingProgramController.java
@@ -44,6 +44,7 @@ public class TrainingProgramController {
     private final ProgramRequirementService programRequirementService;
     private final CertificateService certificateService;
     private final ProgramTrainingApplicationService programTrainingApplicationService;
+    private final ProgramReviewService programReviewService;
 
     // ===== PROGRAM BASIC OPERATIONS =====
 
@@ -298,6 +299,69 @@ public class TrainingProgramController {
         double completionRate = trainingProgramService.getProgramCompletionRate(programUuid);
         return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
                 .success(completionRate, "Program completion rate retrieved successfully"));
+    }
+
+    // ===== PROGRAM REVIEWS =====
+
+    @Operation(
+            summary = "Submit or update a program review",
+            description = """
+                    Allows students with an active or completed program enrollment to leave a review.
+                    Each student can leave one review per program and may update it anytime.
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "Program review saved successfully",
+                            content = @Content(schema = @Schema(implementation = ProgramReviewDTO.class))),
+                    @ApiResponse(responseCode = "400", description = "Invalid review payload"),
+                    @ApiResponse(responseCode = "404", description = "Program not found"),
+                    @ApiResponse(responseCode = "409", description = "Student is not eligible to review this program")
+            }
+    )
+    @PostMapping("/{programUuid}/reviews")
+    public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<ProgramReviewDTO>> submitProgramReview(
+            @PathVariable UUID programUuid,
+            @Valid @RequestBody ProgramReviewRequest reviewRequest) {
+        ProgramReviewDTO savedReview = programReviewService.saveProgramReview(programUuid, reviewRequest);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(apps.sarafrika.elimika.shared.dto.ApiResponse
+                        .success(savedReview, "Program review saved successfully"));
+    }
+
+    @Operation(
+            summary = "Get reviews for a program",
+            description = "Returns paginated public reviews for the specified training program.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Program reviews fetched successfully",
+                            content = @Content(schema = @Schema(implementation = PagedDTO.class))),
+                    @ApiResponse(responseCode = "404", description = "Program not found")
+            }
+    )
+    @GetMapping("/{programUuid}/reviews")
+    public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<PagedDTO<ProgramReviewDTO>>> getProgramReviews(
+            @PathVariable UUID programUuid,
+            Pageable pageable) {
+        Page<ProgramReviewDTO> reviews = programReviewService.getReviewsForProgram(programUuid, pageable);
+        return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
+                .success(PagedDTO.from(reviews, ServletUriComponentsBuilder
+                                .fromCurrentRequestUri().build().toString()),
+                        "Program reviews fetched successfully"));
+    }
+
+    @Operation(
+            summary = "Get program rating summary",
+            description = "Returns the average rating and total review count for a training program.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Program rating summary fetched successfully",
+                            content = @Content(schema = @Schema(implementation = ProgramRatingSummaryDTO.class))),
+                    @ApiResponse(responseCode = "404", description = "Program not found")
+            }
+    )
+    @GetMapping("/{programUuid}/reviews/summary")
+    public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<ProgramRatingSummaryDTO>> getProgramRatingSummary(
+            @PathVariable UUID programUuid) {
+        ProgramRatingSummaryDTO summary = programReviewService.getRatingSummary(programUuid);
+        return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
+                .success(summary, "Program rating summary fetched successfully"));
     }
 
     // ===== PROGRAM REQUIREMENTS =====

--- a/src/main/resources/db/migration/V202606111233__create_program_reviews_table.sql
+++ b/src/main/resources/db/migration/V202606111233__create_program_reviews_table.sql
@@ -1,0 +1,30 @@
+-- Create program_reviews table to store student feedback about training programs
+
+CREATE TABLE program_reviews (
+    id BIGSERIAL PRIMARY KEY,
+    uuid UUID NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+    program_uuid UUID NOT NULL REFERENCES training_programs (uuid) ON DELETE CASCADE,
+    student_uuid UUID NOT NULL REFERENCES students (uuid) ON DELETE CASCADE,
+
+    rating INTEGER NOT NULL CHECK (rating BETWEEN 1 AND 5),
+    headline VARCHAR(255),
+    comments TEXT,
+
+    is_anonymous BOOLEAN NOT NULL DEFAULT false,
+
+    created_date TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    updated_date TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    created_by VARCHAR(255) NOT NULL,
+    updated_by VARCHAR(255)
+);
+
+CREATE INDEX idx_program_reviews_program ON program_reviews (program_uuid);
+CREATE INDEX idx_program_reviews_student ON program_reviews (student_uuid);
+
+ALTER TABLE program_reviews
+    ADD CONSTRAINT uq_program_review_per_student UNIQUE (program_uuid, student_uuid);
+
+COMMENT ON TABLE program_reviews IS 'Student reviews and ratings for training programs.';
+COMMENT ON COLUMN program_reviews.rating IS 'Overall star rating (1-5) provided by the student.';
+COMMENT ON COLUMN program_reviews.is_anonymous IS 'When true, public displays should hide the student identity.';

--- a/src/test/java/apps/sarafrika/elimika/course/controller/TrainingProgramControllerTest.java
+++ b/src/test/java/apps/sarafrika/elimika/course/controller/TrainingProgramControllerTest.java
@@ -1,0 +1,163 @@
+package apps.sarafrika.elimika.course.controller;
+
+import apps.sarafrika.elimika.course.dto.ProgramRatingSummaryDTO;
+import apps.sarafrika.elimika.course.dto.ProgramReviewDTO;
+import apps.sarafrika.elimika.course.dto.ProgramReviewRequest;
+import apps.sarafrika.elimika.course.service.CertificateService;
+import apps.sarafrika.elimika.course.service.ProgramCourseService;
+import apps.sarafrika.elimika.course.service.ProgramEnrollmentService;
+import apps.sarafrika.elimika.course.service.ProgramRequirementService;
+import apps.sarafrika.elimika.course.service.ProgramReviewService;
+import apps.sarafrika.elimika.course.service.ProgramTrainingApplicationService;
+import apps.sarafrika.elimika.course.service.TrainingProgramService;
+import apps.sarafrika.elimika.shared.config.GlobalExceptionHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class TrainingProgramControllerTest {
+
+    @Mock
+    private TrainingProgramService trainingProgramService;
+    @Mock
+    private ProgramCourseService programCourseService;
+    @Mock
+    private ProgramEnrollmentService programEnrollmentService;
+    @Mock
+    private ProgramRequirementService programRequirementService;
+    @Mock
+    private CertificateService certificateService;
+    @Mock
+    private ProgramTrainingApplicationService programTrainingApplicationService;
+    @Mock
+    private ProgramReviewService programReviewService;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        TrainingProgramController controller = new TrainingProgramController(
+                trainingProgramService,
+                programCourseService,
+                programEnrollmentService,
+                programRequirementService,
+                certificateService,
+                programTrainingApplicationService,
+                programReviewService
+        );
+
+        objectMapper = new ObjectMapper();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .build();
+    }
+
+    @Test
+    void submitProgramReviewUsesPathProgramUuidAndReturnsCreated() throws Exception {
+        UUID programUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        ProgramReviewRequest request = request(studentUuid);
+        ProgramReviewDTO response = review(programUuid, studentUuid, 5);
+
+        when(programReviewService.saveProgramReview(eq(programUuid), any(ProgramReviewRequest.class)))
+                .thenReturn(response);
+
+        mockMvc.perform(post("/api/v1/programs/{programUuid}/reviews", programUuid)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.program_uuid").value(programUuid.toString()))
+                .andExpect(jsonPath("$.data.student_uuid").value(studentUuid.toString()))
+                .andExpect(jsonPath("$.data.rating").value(5));
+
+        ArgumentCaptor<ProgramReviewRequest> captor = ArgumentCaptor.forClass(ProgramReviewRequest.class);
+        verify(programReviewService).saveProgramReview(eq(programUuid), captor.capture());
+        assertThat(captor.getValue().studentUuid()).isEqualTo(studentUuid);
+    }
+
+    @Test
+    void getProgramReviewsReturnsPagedResponse() throws Exception {
+        UUID programUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        when(programReviewService.getReviewsForProgram(eq(programUuid), any(Pageable.class)))
+                .thenReturn(new PageImpl<>(List.of(review(programUuid, studentUuid, 4)), pageable, 1));
+
+        mockMvc.perform(get("/api/v1/programs/{programUuid}/reviews?page=0&size=20", programUuid))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.content[0].program_uuid").value(programUuid.toString()))
+                .andExpect(jsonPath("$.data.content[0].rating").value(4))
+                .andExpect(jsonPath("$.data.metadata.totalElements").value(1));
+    }
+
+    @Test
+    void getProgramRatingSummaryReturnsAverageAndCount() throws Exception {
+        UUID programUuid = UUID.randomUUID();
+
+        when(programReviewService.getRatingSummary(programUuid))
+                .thenReturn(new ProgramRatingSummaryDTO(programUuid, 4.5, 2L));
+
+        mockMvc.perform(get("/api/v1/programs/{programUuid}/reviews/summary", programUuid))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.program_uuid").value(programUuid.toString()))
+                .andExpect(jsonPath("$.data.average_rating").value(4.5))
+                .andExpect(jsonPath("$.data.review_count").value(2));
+    }
+
+    private ProgramReviewRequest request(UUID studentUuid) {
+        return new ProgramReviewRequest(
+                studentUuid,
+                5,
+                "Excellent pathway",
+                "The sequence was practical.",
+                false
+        );
+    }
+
+    private ProgramReviewDTO review(UUID programUuid, UUID studentUuid, int rating) {
+        return new ProgramReviewDTO(
+                UUID.randomUUID(),
+                programUuid,
+                studentUuid,
+                rating,
+                "Excellent pathway",
+                "The sequence was practical.",
+                false,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/src/test/java/apps/sarafrika/elimika/course/service/impl/ProgramReviewServiceImplTest.java
+++ b/src/test/java/apps/sarafrika/elimika/course/service/impl/ProgramReviewServiceImplTest.java
@@ -1,0 +1,220 @@
+package apps.sarafrika.elimika.course.service.impl;
+
+import apps.sarafrika.elimika.course.dto.ProgramRatingSummaryDTO;
+import apps.sarafrika.elimika.course.dto.ProgramReviewDTO;
+import apps.sarafrika.elimika.course.dto.ProgramReviewRequest;
+import apps.sarafrika.elimika.course.model.ProgramReview;
+import apps.sarafrika.elimika.course.repository.ProgramEnrollmentRepository;
+import apps.sarafrika.elimika.course.repository.ProgramReviewRepository;
+import apps.sarafrika.elimika.course.repository.TrainingProgramRepository;
+import apps.sarafrika.elimika.course.util.enums.EnrollmentStatus;
+import apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ProgramReviewServiceImplTest {
+
+    @Mock
+    private ProgramReviewRepository programReviewRepository;
+
+    @Mock
+    private ProgramEnrollmentRepository programEnrollmentRepository;
+
+    @Mock
+    private TrainingProgramRepository trainingProgramRepository;
+
+    private ProgramReviewServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ProgramReviewServiceImpl(
+                programReviewRepository,
+                programEnrollmentRepository,
+                trainingProgramRepository
+        );
+    }
+
+    @Test
+    void saveProgramReviewCreatesReviewForActiveEnrollment() {
+        UUID programUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+
+        when(trainingProgramRepository.existsByUuid(programUuid)).thenReturn(true);
+        when(programEnrollmentRepository.existsByStudentUuidAndProgramUuidAndStatusIn(
+                eq(studentUuid),
+                eq(programUuid),
+                eq(Set.of(EnrollmentStatus.ACTIVE, EnrollmentStatus.COMPLETED))
+        )).thenReturn(true);
+        when(programReviewRepository.findByProgramUuidAndStudentUuid(programUuid, studentUuid))
+                .thenReturn(Optional.empty());
+        when(programReviewRepository.save(any(ProgramReview.class))).thenAnswer(invocation -> {
+            ProgramReview review = invocation.getArgument(0);
+            review.setUuid(UUID.randomUUID());
+            return review;
+        });
+
+        ProgramReviewDTO saved = service.saveProgramReview(programUuid, request(studentUuid, 5, false));
+
+        ArgumentCaptor<ProgramReview> captor = ArgumentCaptor.forClass(ProgramReview.class);
+        verify(programReviewRepository).save(captor.capture());
+        ProgramReview review = captor.getValue();
+
+        assertThat(review.getProgramUuid()).isEqualTo(programUuid);
+        assertThat(review.getStudentUuid()).isEqualTo(studentUuid);
+        assertThat(review.getRating()).isEqualTo(5);
+        assertThat(review.getIsAnonymous()).isFalse();
+        assertThat(saved.uuid()).isNotNull();
+    }
+
+    @Test
+    void saveProgramReviewUpdatesExistingReviewForCompletedEnrollment() {
+        UUID programUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        ProgramReview existing = review(programUuid, studentUuid, 3, false);
+
+        when(trainingProgramRepository.existsByUuid(programUuid)).thenReturn(true);
+        when(programEnrollmentRepository.existsByStudentUuidAndProgramUuidAndStatusIn(
+                eq(studentUuid),
+                eq(programUuid),
+                eq(Set.of(EnrollmentStatus.ACTIVE, EnrollmentStatus.COMPLETED))
+        )).thenReturn(true);
+        when(programReviewRepository.findByProgramUuidAndStudentUuid(programUuid, studentUuid))
+                .thenReturn(Optional.of(existing));
+        when(programReviewRepository.save(any(ProgramReview.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        ProgramReviewDTO saved = service.saveProgramReview(programUuid, request(studentUuid, 4, true));
+
+        assertThat(saved.rating()).isEqualTo(4);
+        assertThat(saved.isAnonymous()).isTrue();
+        assertThat(saved.studentUuid()).isNull();
+        assertThat(existing.getRating()).isEqualTo(4);
+        assertThat(existing.getIsAnonymous()).isTrue();
+    }
+
+    @Test
+    void saveProgramReviewRejectsIneligibleEnrollment() {
+        UUID programUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+
+        when(trainingProgramRepository.existsByUuid(programUuid)).thenReturn(true);
+        when(programEnrollmentRepository.existsByStudentUuidAndProgramUuidAndStatusIn(
+                eq(studentUuid),
+                eq(programUuid),
+                eq(Set.of(EnrollmentStatus.ACTIVE, EnrollmentStatus.COMPLETED))
+        )).thenReturn(false);
+
+        assertThatThrownBy(() -> service.saveProgramReview(programUuid, request(studentUuid, 5, false)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("active or completed program enrollment");
+
+        verify(programReviewRepository, never()).save(any(ProgramReview.class));
+    }
+
+    @Test
+    void saveProgramReviewRejectsMissingProgram() {
+        UUID programUuid = UUID.randomUUID();
+
+        when(trainingProgramRepository.existsByUuid(programUuid)).thenReturn(false);
+
+        assertThatThrownBy(() -> service.saveProgramReview(programUuid, request(UUID.randomUUID(), 5, false)))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Training program");
+    }
+
+    @Test
+    void getReviewsForProgramMasksAnonymousIdentity() {
+        UUID programUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        PageRequest pageable = PageRequest.of(0, 10);
+        ProgramReview anonymousReview = review(programUuid, studentUuid, 5, true);
+
+        when(trainingProgramRepository.existsByUuid(programUuid)).thenReturn(true);
+        when(programReviewRepository.findByProgramUuid(programUuid, pageable))
+                .thenReturn(new PageImpl<>(List.of(anonymousReview), pageable, 1));
+
+        Page<ProgramReviewDTO> reviews = service.getReviewsForProgram(programUuid, pageable);
+
+        ProgramReviewDTO dto = reviews.getContent().getFirst();
+        assertThat(dto.studentUuid()).isNull();
+        assertThat(dto.createdBy()).isNull();
+        assertThat(dto.updatedBy()).isNull();
+        assertThat(dto.rating()).isEqualTo(5);
+    }
+
+    @Test
+    void getRatingSummaryReturnsNullAverageWhenNoReviewsExist() {
+        UUID programUuid = UUID.randomUUID();
+
+        when(trainingProgramRepository.existsByUuid(programUuid)).thenReturn(true);
+        when(programReviewRepository.countByProgramUuid(programUuid)).thenReturn(0L);
+
+        ProgramRatingSummaryDTO summary = service.getRatingSummary(programUuid);
+
+        assertThat(summary.programUuid()).isEqualTo(programUuid);
+        assertThat(summary.averageRating()).isNull();
+        assertThat(summary.reviewCount()).isZero();
+        verify(programReviewRepository, never()).findAverageRatingForProgram(programUuid);
+    }
+
+    @Test
+    void getRatingSummaryReturnsAverageAndCount() {
+        UUID programUuid = UUID.randomUUID();
+
+        when(trainingProgramRepository.existsByUuid(programUuid)).thenReturn(true);
+        when(programReviewRepository.countByProgramUuid(programUuid)).thenReturn(2L);
+        when(programReviewRepository.findAverageRatingForProgram(programUuid)).thenReturn(4.5);
+
+        ProgramRatingSummaryDTO summary = service.getRatingSummary(programUuid);
+
+        assertThat(summary.averageRating()).isEqualTo(4.5);
+        assertThat(summary.reviewCount()).isEqualTo(2L);
+    }
+
+    private ProgramReviewRequest request(UUID studentUuid, int rating, boolean anonymous) {
+        return new ProgramReviewRequest(
+                studentUuid,
+                rating,
+                "Excellent pathway",
+                "The sequence was practical.",
+                anonymous
+        );
+    }
+
+    private ProgramReview review(UUID programUuid, UUID studentUuid, int rating, boolean anonymous) {
+        ProgramReview review = new ProgramReview();
+        review.setUuid(UUID.randomUUID());
+        review.setProgramUuid(programUuid);
+        review.setStudentUuid(studentUuid);
+        review.setRating(rating);
+        review.setHeadline("Excellent pathway");
+        review.setComments("The sequence was practical.");
+        review.setIsAnonymous(anonymous);
+        review.setCreatedDate(LocalDateTime.now());
+        review.setCreatedBy("student@example.com");
+        review.setLastModifiedDate(LocalDateTime.now());
+        review.setLastModifiedBy("student@example.com");
+        return review;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a program review and rating API for training programs.
- Keeps review storage and service logic inside the existing course module.
- Uses paginated review listing and OpenAPI-documented endpoints.

## Changes
- Adds the program_reviews Flyway migration with rating constraints, anonymity flag, audit fields, indexes, and one-review-per-student-per-program uniqueness.
- Adds ProgramReview request/response/summary DTOs, entity, repository, factory, and service layer.
- Adds POST /api/v1/programs/{programUuid}/reviews, GET /api/v1/programs/{programUuid}/reviews, and GET /api/v1/programs/{programUuid}/reviews/summary.
- Enforces active or completed program enrollment before review submission and masks anonymous public reviewer identity.

## Tests
- /usr/bin/env JAVA_HOME=/home/willy/.jdks/temurin-21.0.11 ./gradlew test
- Result: BUILD SUCCESSFUL

## Configuration/Secret Impacts
- None.