### PR TITLE
fix: repair student assignment submission flow

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/course/dto/AssignmentSubmissionRequest.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/AssignmentSubmissionRequest.java
@@ -1,0 +1,45 @@
+package apps.sarafrika.elimika.course.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+import java.util.UUID;
+
+@Schema(
+        name = "AssignmentSubmissionRequest",
+        description = "Student assignment submission request"
+)
+public record AssignmentSubmissionRequest(
+
+        @Schema(
+                description = "Course enrollment UUID for the student submitting the assignment.",
+                example = "e1n2r3o4-5l6l-7m8e-9n10-abcdefghijkl"
+        )
+        @JsonProperty("enrollment_uuid")
+        UUID enrollmentUuid,
+
+        @Schema(
+                description = "Student UUID. Used to resolve the active course enrollment when enrollment_uuid is omitted.",
+                example = "s1t2u3d4-5e6n-7t8u-9u10-abcdefghijkl"
+        )
+        @JsonProperty("student_uuid")
+        UUID studentUuid,
+
+        @Schema(
+                description = "Text content of the student's submission.",
+                example = "My assignment response.",
+                maxLength = 10000
+        )
+        @Size(max = 10000, message = "Submission text must not exceed 10000 characters")
+        @JsonProperty("submission_text")
+        String submissionText,
+
+        @Schema(
+                description = "External or previously uploaded file URLs attached to this submission.",
+                example = "[\"https://storage.sarafrika.com/submissions/work.pdf\"]"
+        )
+        @JsonProperty("file_urls")
+        String[] fileUrls
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/course/internal/AssignmentMediaValidationService.java
+++ b/src/main/java/apps/sarafrika/elimika/course/internal/AssignmentMediaValidationService.java
@@ -22,6 +22,12 @@ public class AssignmentMediaValidationService {
             "VIDEO",
             "URL"
     );
+    private static final Set<String> FILE_SUBMISSION_TYPES = Set.of(
+            "DOCUMENT",
+            "IMAGE",
+            "AUDIO",
+            "VIDEO"
+    );
 
     private static final long MAX_IMAGE_SIZE = 10 * 1024 * 1024;    // 10MB
     private static final long MAX_DOCUMENT_SIZE = 50 * 1024 * 1024; // 50MB
@@ -66,20 +72,28 @@ public class AssignmentMediaValidationService {
     }
 
     public void validateSubmissionRequest(String[] submissionTypes, String content, String[] fileUrls) {
+        validateSubmissionRequest(submissionTypes, content, fileUrls, false);
+    }
+
+    public void validateSubmissionRequest(String[] submissionTypes, String content, String[] fileUrls, boolean hasUploadedFiles) {
         Set<String> normalizedTypes = normalizeSubmissionTypeSet(submissionTypes);
+        boolean hasText = content != null && !content.isBlank();
+        boolean hasFiles = fileUrls != null && Arrays.stream(fileUrls).anyMatch(url -> url != null && !url.isBlank());
+
+        if (!hasText && !hasFiles && !hasUploadedFiles) {
+            throw new IllegalArgumentException("Submission must include text or file attachments.");
+        }
+
         if (normalizedTypes.isEmpty()) {
             return;
         }
 
-        boolean hasText = content != null && !content.isBlank();
-        boolean hasFiles = fileUrls != null && Arrays.stream(fileUrls).anyMatch(url -> url != null && !url.isBlank());
-
-        if (!hasText && !hasFiles) {
-            throw new IllegalArgumentException("Submission must include text or file attachments.");
-        }
-
         if (hasText && !normalizedTypes.contains("TEXT") && !normalizedTypes.contains("URL")) {
             throw new IllegalArgumentException("Text submissions are not allowed for this assignment.");
+        }
+
+        if (hasUploadedFiles && normalizedTypes.stream().noneMatch(FILE_SUBMISSION_TYPES::contains)) {
+            throw new IllegalArgumentException("File submissions are not allowed for this assignment.");
         }
 
         if (hasFiles) {

--- a/src/main/java/apps/sarafrika/elimika/course/service/AssignmentSubmissionService.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/AssignmentSubmissionService.java
@@ -1,6 +1,7 @@
 package apps.sarafrika.elimika.course.service;
 
 import apps.sarafrika.elimika.course.dto.AssignmentSubmissionDTO;
+import apps.sarafrika.elimika.course.dto.AssignmentSubmissionRequest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -27,15 +28,25 @@ public interface AssignmentSubmissionService {
     // ===== SUBMISSION WORKFLOW OPERATIONS =====
 
     /**
-     * Submit an assignment for a student
-     * @param enrollmentUuid The student's enrollment UUID
+     * Submit an assignment for a student.
+     *
      * @param assignmentUuid The assignment UUID
-     * @param content The submission content
-     * @param fileUrls Optional file URLs
-     * @return Created submission DTO
+     * @param request The submission request
+     * @param hasUploadedFiles Whether multipart files are attached to the same request
+     * @return Created or resubmitted submission DTO
      */
-    AssignmentSubmissionDTO submitAssignment(UUID enrollmentUuid, UUID assignmentUuid,
-                                             String content, String[] fileUrls);
+    AssignmentSubmissionDTO submitAssignment(UUID assignmentUuid,
+                                             AssignmentSubmissionRequest request,
+                                             boolean hasUploadedFiles);
+
+    default AssignmentSubmissionDTO submitAssignment(UUID enrollmentUuid, UUID assignmentUuid,
+                                                     String content, String[] fileUrls) {
+        return submitAssignment(
+                assignmentUuid,
+                new AssignmentSubmissionRequest(enrollmentUuid, null, content, fileUrls),
+                false
+        );
+    }
 
     /**
      * Get all submissions for a specific assignment

--- a/src/main/java/apps/sarafrika/elimika/course/service/impl/AssignmentSubmissionServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/impl/AssignmentSubmissionServiceImpl.java
@@ -1,25 +1,31 @@
 package apps.sarafrika.elimika.course.service.impl;
 
 import apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException;
+import apps.sarafrika.elimika.shared.security.DomainSecurityService;
 import apps.sarafrika.elimika.shared.utils.GenericSpecificationBuilder;
 import apps.sarafrika.elimika.course.dto.AssignmentSubmissionDTO;
+import apps.sarafrika.elimika.course.dto.AssignmentSubmissionRequest;
 import apps.sarafrika.elimika.course.factory.AssignmentSubmissionFactory;
 import apps.sarafrika.elimika.course.internal.AssignmentMediaValidationService;
 import apps.sarafrika.elimika.course.model.Assignment;
 import apps.sarafrika.elimika.course.model.AssignmentSubmission;
 import apps.sarafrika.elimika.course.model.CourseEnrollment;
+import apps.sarafrika.elimika.course.model.Lesson;
 import apps.sarafrika.elimika.course.repository.AssignmentRepository;
 import apps.sarafrika.elimika.course.repository.CourseEnrollmentRepository;
 import apps.sarafrika.elimika.course.repository.AssignmentSubmissionRepository;
+import apps.sarafrika.elimika.course.repository.LessonRepository;
 import apps.sarafrika.elimika.course.service.AssignmentSubmissionService;
 import apps.sarafrika.elimika.course.service.CourseGradeBookService;
 import apps.sarafrika.elimika.course.spi.AssessmentCompletedNotificationRequestedEvent;
+import apps.sarafrika.elimika.course.util.enums.EnrollmentStatus;
 import apps.sarafrika.elimika.course.util.enums.SubmissionStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,6 +48,8 @@ public class AssignmentSubmissionServiceImpl implements AssignmentSubmissionServ
     private final AssignmentMediaValidationService assignmentMediaValidationService;
     private final CourseGradeBookService courseGradeBookService;
     private final CourseEnrollmentRepository courseEnrollmentRepository;
+    private final LessonRepository lessonRepository;
+    private final DomainSecurityService domainSecurityService;
     private final ApplicationEventPublisher eventPublisher;
 
     private static final String SUBMISSION_NOT_FOUND_TEMPLATE = "Assignment submission with ID %s not found";
@@ -124,33 +132,31 @@ public class AssignmentSubmissionServiceImpl implements AssignmentSubmissionServ
     // ===== SUBMISSION WORKFLOW OPERATIONS =====
 
     @Override
-    public AssignmentSubmissionDTO submitAssignment(UUID enrollmentUuid, UUID assignmentUuid,
-                                                    String content, String[] fileUrls) {
-        Assignment assignment = assignmentRepository.findByUuid(assignmentUuid)
-                .orElseThrow(() -> new ResourceNotFoundException(
-                        String.format("Assignment with ID %s not found", assignmentUuid)));
+    public AssignmentSubmissionDTO submitAssignment(UUID assignmentUuid,
+                                                    AssignmentSubmissionRequest request,
+                                                    boolean hasUploadedFiles) {
+        if (request == null) {
+            throw new IllegalArgumentException("Submission request is required");
+        }
 
+        Assignment assignment = getAssignmentOrThrow(assignmentUuid);
+        enforcePublishedAssignment(assignment);
         assignmentMediaValidationService.validateSubmissionRequest(
                 assignment.getSubmissionTypes(),
-                content,
-                fileUrls
+                request.submissionText(),
+                request.fileUrls(),
+                hasUploadedFiles
         );
+        CourseEnrollment enrollment = resolveCourseEnrollment(request, assignment);
+        enforceSubmitterCanUseEnrollment(enrollment);
 
-        // Check if student already has a submission for this assignment
-        assignmentSubmissionRepository.findByEnrollmentUuidAndAssignmentUuid(enrollmentUuid, assignmentUuid)
-                .ifPresent(existing -> {
-                    throw new IllegalStateException("Student has already submitted this assignment");
-                });
-
-        AssignmentSubmission submission = new AssignmentSubmission();
-        submission.setEnrollmentUuid(enrollmentUuid);
-        submission.setAssignmentUuid(assignmentUuid);
-        submission.setSubmissionText(content);
-        submission.setFileUrls(fileUrls);
-        submission.setSubmittedAt(LocalDateTime.now());
-        submission.setStatus(SubmissionStatus.SUBMITTED);
+        AssignmentSubmission submission = assignmentSubmissionRepository
+                .findByEnrollmentUuidAndAssignmentUuid(enrollment.getUuid(), assignmentUuid)
+                .map(existing -> prepareResubmission(existing, request))
+                .orElseGet(() -> newSubmission(enrollment.getUuid(), assignmentUuid, request));
 
         AssignmentSubmission savedSubmission = assignmentSubmissionRepository.save(submission);
+        publishAssessmentCompletedNotification(savedSubmission, assignment.getTitle(), "assignment");
         return AssignmentSubmissionFactory.toDTO(savedSubmission);
     }
 
@@ -301,6 +307,98 @@ public class AssignmentSubmissionServiceImpl implements AssignmentSubmissionServ
         if (dto.gradedByUuid() != null) {
             existingSubmission.setGradedByUuid(dto.gradedByUuid());
         }
+    }
+
+    private Assignment getAssignmentOrThrow(UUID assignmentUuid) {
+        return assignmentRepository.findByUuid(assignmentUuid)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        String.format("Assignment with ID %s not found", assignmentUuid)));
+    }
+
+    private void enforcePublishedAssignment(Assignment assignment) {
+        if (!Boolean.TRUE.equals(assignment.getIsPublished())) {
+            throw new IllegalStateException("Assignment is not published.");
+        }
+    }
+
+    private CourseEnrollment resolveCourseEnrollment(AssignmentSubmissionRequest request, Assignment assignment) {
+        UUID courseUuid = resolveAssignmentCourseUuid(assignment);
+
+        CourseEnrollment enrollment;
+        if (request.enrollmentUuid() != null) {
+            enrollment = courseEnrollmentRepository.findByUuid(request.enrollmentUuid())
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            String.format("Course enrollment with ID %s not found", request.enrollmentUuid())));
+            if (!courseUuid.equals(enrollment.getCourseUuid())) {
+                throw new IllegalArgumentException("Course enrollment does not belong to the assignment course.");
+            }
+            if (request.studentUuid() != null && !request.studentUuid().equals(enrollment.getStudentUuid())) {
+                throw new IllegalArgumentException("student_uuid does not match enrollment_uuid.");
+            }
+        } else {
+            if (request.studentUuid() == null) {
+                throw new IllegalArgumentException("Either enrollment_uuid or student_uuid is required.");
+            }
+            enrollment = courseEnrollmentRepository.findByStudentUuidAndCourseUuid(request.studentUuid(), courseUuid)
+                    .orElseThrow(() -> new ResourceNotFoundException(
+                            String.format("Active course enrollment for student %s and assignment course not found",
+                                    request.studentUuid())));
+        }
+
+        if (!EnrollmentStatus.ACTIVE.equals(enrollment.getStatus())) {
+            throw new IllegalStateException("Course enrollment must be active to submit assignments.");
+        }
+
+        return enrollment;
+    }
+
+    private UUID resolveAssignmentCourseUuid(Assignment assignment) {
+        Lesson lesson = lessonRepository.findByUuid(assignment.getLessonUuid())
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        String.format("Lesson with ID %s not found", assignment.getLessonUuid())));
+        return lesson.getCourseUuid();
+    }
+
+    private void enforceSubmitterCanUseEnrollment(CourseEnrollment enrollment) {
+        if (domainSecurityService.isInstructorOrAdmin()) {
+            return;
+        }
+        if (!domainSecurityService.isStudentWithUuid(enrollment.getStudentUuid())) {
+            throw new AccessDeniedException("Students may only submit assignments for their own course enrollment.");
+        }
+    }
+
+    private AssignmentSubmission prepareResubmission(AssignmentSubmission existingSubmission,
+                                                    AssignmentSubmissionRequest request) {
+        SubmissionStatus status = existingSubmission.getStatus();
+        if (status != SubmissionStatus.DRAFT && status != SubmissionStatus.RETURNED) {
+            throw new IllegalStateException("Student has already submitted this assignment");
+        }
+
+        existingSubmission.setSubmissionText(request.submissionText());
+        existingSubmission.setFileUrls(request.fileUrls());
+        existingSubmission.setSubmittedAt(LocalDateTime.now());
+        existingSubmission.setStatus(SubmissionStatus.SUBMITTED);
+        existingSubmission.setScore(null);
+        existingSubmission.setMaxScore(null);
+        existingSubmission.setPercentage(null);
+        existingSubmission.setInstructorComments(null);
+        existingSubmission.setGradedAt(null);
+        existingSubmission.setGradedByUuid(null);
+        return existingSubmission;
+    }
+
+    private AssignmentSubmission newSubmission(UUID enrollmentUuid,
+                                               UUID assignmentUuid,
+                                               AssignmentSubmissionRequest request) {
+        AssignmentSubmission submission = new AssignmentSubmission();
+        submission.setEnrollmentUuid(enrollmentUuid);
+        submission.setAssignmentUuid(assignmentUuid);
+        submission.setSubmissionText(request.submissionText());
+        submission.setFileUrls(request.fileUrls());
+        submission.setSubmittedAt(LocalDateTime.now());
+        submission.setStatus(SubmissionStatus.SUBMITTED);
+        return submission;
     }
 
     private void publishAssessmentCompletedNotification(AssignmentSubmission submission,

--- a/src/main/java/apps/sarafrika/elimika/shared/controller/AssignmentController.java
+++ b/src/main/java/apps/sarafrika/elimika/shared/controller/AssignmentController.java
@@ -29,6 +29,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriUtils;
 
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -240,17 +241,95 @@ public class AssignmentController {
             summary = "Submit assignment",
             description = "Creates a new submission for an assignment by a student."
     )
-    @PostMapping("/{assignmentUuid}/submit")
+    @PostMapping(
+            value = "/{assignmentUuid}/submit",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<AssignmentSubmissionDTO>> submitAssignment(
+            @PathVariable UUID assignmentUuid,
+            @Valid @RequestBody AssignmentSubmissionRequest request) {
+        AssignmentSubmissionDTO submission = assignmentSubmissionService.submitAssignment(
+                assignmentUuid, request, false);
+        return assignmentSubmittedResponse(submission);
+    }
+
+    @Operation(
+            summary = "Submit assignment with files",
+            description = "Creates or resubmits an assignment submission and stores uploaded files as submission attachments."
+    )
+    @PostMapping(
+            value = "/{assignmentUuid}/submit",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<AssignmentSubmissionDTO>> submitAssignmentMultipart(
+            @PathVariable UUID assignmentUuid,
+            @RequestParam(value = "enrollment_uuid", required = false) UUID enrollmentUuid,
+            @RequestParam(value = "student_uuid", required = false) UUID studentUuid,
+            @RequestParam(value = "submission_text", required = false) String submissionText,
+            @RequestParam(value = "file_urls", required = false) String[] fileUrls,
+            @RequestParam(value = "enrollmentUuid", required = false) UUID legacyEnrollmentUuid,
+            @RequestParam(value = "studentUuid", required = false) UUID legacyStudentUuid,
+            @RequestParam(value = "content", required = false) String legacyContent,
+            @RequestParam(value = "fileUrls", required = false) String[] legacyFileUrls,
+            @RequestParam(value = "files", required = false) List<MultipartFile> files,
+            @RequestParam(value = "file", required = false) MultipartFile file) {
+        List<MultipartFile> uploadedFiles = collectUploadedFiles(files, file);
+        if (!uploadedFiles.isEmpty()) {
+            AssignmentDTO assignment = assignmentService.getAssignmentByUuid(assignmentUuid);
+            uploadedFiles.forEach(uploadedFile ->
+                    assignmentMediaValidationService.validateSubmissionAttachment(assignment.submissionTypes(), uploadedFile));
+        }
+
+        AssignmentSubmissionRequest request = new AssignmentSubmissionRequest(
+                enrollmentUuid != null ? enrollmentUuid : legacyEnrollmentUuid,
+                studentUuid != null ? studentUuid : legacyStudentUuid,
+                submissionText != null ? submissionText : legacyContent,
+                fileUrls != null ? fileUrls : legacyFileUrls
+        );
+
+        AssignmentSubmissionDTO submission = assignmentSubmissionService.submitAssignment(
+                assignmentUuid, request, !uploadedFiles.isEmpty());
+        storeSubmissionFiles(assignmentUuid, submission.uuid(), uploadedFiles);
+        return assignmentSubmittedResponse(submission);
+    }
+
+    @Operation(
+            summary = "Submit assignment using legacy query parameters",
+            description = "Creates a new submission for an assignment using the previous query-parameter contract."
+    )
+    @PostMapping(value = "/{assignmentUuid}/submit", params = "enrollmentUuid")
+    public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<AssignmentSubmissionDTO>> submitAssignmentLegacy(
             @PathVariable UUID assignmentUuid,
             @RequestParam UUID enrollmentUuid,
             @RequestParam(required = false) String content,
             @RequestParam(required = false) String[] fileUrls) {
         AssignmentSubmissionDTO submission = assignmentSubmissionService.submitAssignment(
                 enrollmentUuid, assignmentUuid, content, fileUrls);
-        return ResponseEntity.status(HttpStatus.CREATED)
-                .body(apps.sarafrika.elimika.shared.dto.ApiResponse
-                        .success(submission, "Assignment submitted successfully"));
+        return assignmentSubmittedResponse(submission);
+    }
+
+    @Operation(
+            summary = "Submit assignment using snake-case query parameters",
+            description = "Creates a new submission for an assignment using query parameters with API field names."
+    )
+    @PostMapping(
+            value = "/{assignmentUuid}/submit",
+            params = "enrollment_uuid",
+            consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE
+    )
+    public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<AssignmentSubmissionDTO>> submitAssignmentQuery(
+            @PathVariable UUID assignmentUuid,
+            @RequestParam("enrollment_uuid") UUID enrollmentUuid,
+            @RequestParam(value = "student_uuid", required = false) UUID studentUuid,
+            @RequestParam(value = "submission_text", required = false) String submissionText,
+            @RequestParam(value = "file_urls", required = false) String[] fileUrls) {
+        AssignmentSubmissionDTO submission = assignmentSubmissionService.submitAssignment(
+                assignmentUuid,
+                new AssignmentSubmissionRequest(enrollmentUuid, studentUuid, submissionText, fileUrls),
+                false);
+        return assignmentSubmittedResponse(submission);
     }
 
     @Operation(
@@ -528,5 +607,54 @@ public class AssignmentController {
 
     private String buildSubmissionMediaUrl(String storedFilePath) {
         return API_ROOT_PATH + "/submission-media/" + UriUtils.encodePath(storedFilePath, java.nio.charset.StandardCharsets.UTF_8);
+    }
+
+    private ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<AssignmentSubmissionDTO>> assignmentSubmittedResponse(
+            AssignmentSubmissionDTO submission) {
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(apps.sarafrika.elimika.shared.dto.ApiResponse
+                        .success(submission, "Assignment submitted successfully"));
+    }
+
+    private List<MultipartFile> collectUploadedFiles(List<MultipartFile> files, MultipartFile file) {
+        List<MultipartFile> uploadedFiles = new ArrayList<>();
+        if (files != null) {
+            uploadedFiles.addAll(files);
+        }
+        if (file != null) {
+            uploadedFiles.add(file);
+        }
+        return uploadedFiles;
+    }
+
+    private void storeSubmissionFiles(UUID assignmentUuid, UUID submissionUuid, List<MultipartFile> files) {
+        if (files == null || files.isEmpty()) {
+            return;
+        }
+
+        String folder = storageProperties.getFolders().getAssignments()
+                + "/" + assignmentUuid
+                + "/submissions/" + submissionUuid;
+
+        for (MultipartFile file : files) {
+            String storedFileName = storageService.store(file, folder);
+            String fileUrl = buildSubmissionMediaUrl(storedFileName);
+
+            AssignmentSubmissionAttachmentDTO requestDto = new AssignmentSubmissionAttachmentDTO(
+                    null,
+                    submissionUuid,
+                    file.getOriginalFilename(),
+                    storedFileName,
+                    fileUrl,
+                    file.getSize(),
+                    storageService.getContentType(storedFileName),
+                    null,
+                    null,
+                    null,
+                    null
+            );
+
+            assignmentSubmissionAttachmentService.createAttachment(requestDto);
+        }
     }
 }

--- a/src/test/java/apps/sarafrika/elimika/course/controller/AssignmentControllerTest.java
+++ b/src/test/java/apps/sarafrika/elimika/course/controller/AssignmentControllerTest.java
@@ -1,0 +1,222 @@
+package apps.sarafrika.elimika.course.controller;
+
+import apps.sarafrika.elimika.course.dto.AssignmentDTO;
+import apps.sarafrika.elimika.course.dto.AssignmentSubmissionAttachmentDTO;
+import apps.sarafrika.elimika.course.dto.AssignmentSubmissionDTO;
+import apps.sarafrika.elimika.course.dto.AssignmentSubmissionRequest;
+import apps.sarafrika.elimika.course.internal.AssignmentMediaValidationService;
+import apps.sarafrika.elimika.course.service.AssignmentAttachmentService;
+import apps.sarafrika.elimika.course.service.AssignmentService;
+import apps.sarafrika.elimika.course.service.AssignmentSubmissionAttachmentService;
+import apps.sarafrika.elimika.course.service.AssignmentSubmissionService;
+import apps.sarafrika.elimika.course.util.enums.SubmissionStatus;
+import apps.sarafrika.elimika.shared.config.GlobalExceptionHandler;
+import apps.sarafrika.elimika.shared.storage.config.StorageProperties;
+import apps.sarafrika.elimika.shared.storage.service.StorageService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class AssignmentControllerTest {
+
+    @Mock
+    private AssignmentService assignmentService;
+    @Mock
+    private AssignmentSubmissionService assignmentSubmissionService;
+    @Mock
+    private AssignmentAttachmentService assignmentAttachmentService;
+    @Mock
+    private AssignmentSubmissionAttachmentService assignmentSubmissionAttachmentService;
+    @Mock
+    private AssignmentMediaValidationService assignmentMediaValidationService;
+    @Mock
+    private StorageService storageService;
+
+    private MockMvc mockMvc;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        StorageProperties storageProperties = new StorageProperties();
+        AssignmentController controller = new AssignmentController(
+                assignmentService,
+                assignmentSubmissionService,
+                assignmentAttachmentService,
+                assignmentSubmissionAttachmentService,
+                assignmentMediaValidationService,
+                storageService,
+                storageProperties
+        );
+
+        objectMapper = new ObjectMapper();
+        mockMvc = MockMvcBuilders.standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void submitAssignmentAcceptsSnakeCaseJsonRequest() throws Exception {
+        UUID assignmentUuid = UUID.randomUUID();
+        UUID enrollmentUuid = UUID.randomUUID();
+        AssignmentSubmissionRequest request = new AssignmentSubmissionRequest(
+                enrollmentUuid,
+                null,
+                "My submission",
+                new String[]{"https://example.test/submission.pdf"}
+        );
+
+        when(assignmentSubmissionService.submitAssignment(eq(assignmentUuid), any(AssignmentSubmissionRequest.class), eq(false)))
+                .thenReturn(submission(UUID.randomUUID(), enrollmentUuid, assignmentUuid));
+
+        mockMvc.perform(post("/api/v1/assignments/{assignmentUuid}/submit", assignmentUuid)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.enrollment_uuid").value(enrollmentUuid.toString()))
+                .andExpect(jsonPath("$.data.assignment_uuid").value(assignmentUuid.toString()))
+                .andExpect(jsonPath("$.data.status").value("submitted"));
+
+        ArgumentCaptor<AssignmentSubmissionRequest> captor =
+                ArgumentCaptor.forClass(AssignmentSubmissionRequest.class);
+        verify(assignmentSubmissionService).submitAssignment(eq(assignmentUuid), captor.capture(), eq(false));
+        assertThat(captor.getValue().submissionText()).isEqualTo("My submission");
+        assertThat(captor.getValue().fileUrls()).containsExactly("https://example.test/submission.pdf");
+    }
+
+    @Test
+    void submitAssignmentKeepsLegacyQueryParameterContract() throws Exception {
+        UUID assignmentUuid = UUID.randomUUID();
+        UUID enrollmentUuid = UUID.randomUUID();
+
+        when(assignmentSubmissionService.submitAssignment(eq(enrollmentUuid), eq(assignmentUuid), eq("Legacy content"), isNull()))
+                .thenReturn(submission(UUID.randomUUID(), enrollmentUuid, assignmentUuid));
+
+        mockMvc.perform(post("/api/v1/assignments/{assignmentUuid}/submit", assignmentUuid)
+                        .param("enrollmentUuid", enrollmentUuid.toString())
+                        .param("content", "Legacy content"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.enrollment_uuid").value(enrollmentUuid.toString()));
+
+        verify(assignmentSubmissionService).submitAssignment(enrollmentUuid, assignmentUuid, "Legacy content", null);
+    }
+
+    @Test
+    void submitAssignmentMultipartStoresFilesAsSubmissionAttachments() throws Exception {
+        UUID assignmentUuid = UUID.randomUUID();
+        UUID enrollmentUuid = UUID.randomUUID();
+        UUID submissionUuid = UUID.randomUUID();
+        MockMultipartFile file = new MockMultipartFile(
+                "files",
+                "work.pdf",
+                MediaType.APPLICATION_PDF_VALUE,
+                "PDF".getBytes()
+        );
+
+        when(assignmentService.getAssignmentByUuid(assignmentUuid))
+                .thenReturn(assignment(assignmentUuid, new String[]{"DOCUMENT"}));
+        when(assignmentSubmissionService.submitAssignment(eq(assignmentUuid), any(AssignmentSubmissionRequest.class), eq(true)))
+                .thenReturn(submission(submissionUuid, enrollmentUuid, assignmentUuid));
+        when(storageService.store(any(MultipartFile.class), eq("assignments/" + assignmentUuid + "/submissions/" + submissionUuid)))
+                .thenReturn("assignments/" + assignmentUuid + "/submissions/" + submissionUuid + "/work.pdf");
+        when(storageService.getContentType("assignments/" + assignmentUuid + "/submissions/" + submissionUuid + "/work.pdf"))
+                .thenReturn(MediaType.APPLICATION_PDF_VALUE);
+        when(assignmentSubmissionAttachmentService.createAttachment(any(AssignmentSubmissionAttachmentDTO.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        mockMvc.perform(multipart("/api/v1/assignments/{assignmentUuid}/submit", assignmentUuid)
+                        .file(file)
+                        .param("enrollment_uuid", enrollmentUuid.toString())
+                        .param("submission_text", "See attached work"))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.uuid").value(submissionUuid.toString()));
+
+        verify(assignmentMediaValidationService).validateSubmissionAttachment(
+                eq(new String[]{"DOCUMENT"}),
+                any(MultipartFile.class)
+        );
+
+        ArgumentCaptor<AssignmentSubmissionRequest> requestCaptor =
+                ArgumentCaptor.forClass(AssignmentSubmissionRequest.class);
+        verify(assignmentSubmissionService).submitAssignment(eq(assignmentUuid), requestCaptor.capture(), eq(true));
+        assertThat(requestCaptor.getValue().enrollmentUuid()).isEqualTo(enrollmentUuid);
+        assertThat(requestCaptor.getValue().submissionText()).isEqualTo("See attached work");
+
+        ArgumentCaptor<AssignmentSubmissionAttachmentDTO> attachmentCaptor =
+                ArgumentCaptor.forClass(AssignmentSubmissionAttachmentDTO.class);
+        verify(assignmentSubmissionAttachmentService).createAttachment(attachmentCaptor.capture());
+        assertThat(attachmentCaptor.getValue().submissionUuid()).isEqualTo(submissionUuid);
+        assertThat(attachmentCaptor.getValue().originalFilename()).isEqualTo("work.pdf");
+        assertThat(attachmentCaptor.getValue().mimeType()).isEqualTo(MediaType.APPLICATION_PDF_VALUE);
+    }
+
+    private AssignmentDTO assignment(UUID assignmentUuid, String[] submissionTypes) {
+        return new AssignmentDTO(
+                assignmentUuid,
+                UUID.randomUUID(),
+                null,
+                null,
+                null,
+                "Assignment",
+                null,
+                null,
+                null,
+                BigDecimal.TEN,
+                null,
+                submissionTypes,
+                true,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    private AssignmentSubmissionDTO submission(UUID submissionUuid, UUID enrollmentUuid, UUID assignmentUuid) {
+        return new AssignmentSubmissionDTO(
+                submissionUuid,
+                enrollmentUuid,
+                assignmentUuid,
+                "My submission",
+                null,
+                null,
+                SubmissionStatus.SUBMITTED,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/src/test/java/apps/sarafrika/elimika/course/service/impl/AssignmentSubmissionServiceImplTest.java
+++ b/src/test/java/apps/sarafrika/elimika/course/service/impl/AssignmentSubmissionServiceImplTest.java
@@ -1,0 +1,333 @@
+package apps.sarafrika.elimika.course.service.impl;
+
+import apps.sarafrika.elimika.course.dto.AssignmentSubmissionRequest;
+import apps.sarafrika.elimika.course.internal.AssignmentMediaValidationService;
+import apps.sarafrika.elimika.course.model.Assignment;
+import apps.sarafrika.elimika.course.model.AssignmentSubmission;
+import apps.sarafrika.elimika.course.model.CourseEnrollment;
+import apps.sarafrika.elimika.course.model.Lesson;
+import apps.sarafrika.elimika.course.repository.AssignmentRepository;
+import apps.sarafrika.elimika.course.repository.AssignmentSubmissionRepository;
+import apps.sarafrika.elimika.course.repository.CourseEnrollmentRepository;
+import apps.sarafrika.elimika.course.repository.LessonRepository;
+import apps.sarafrika.elimika.course.service.CourseGradeBookService;
+import apps.sarafrika.elimika.course.spi.AssessmentCompletedNotificationRequestedEvent;
+import apps.sarafrika.elimika.course.util.enums.EnrollmentStatus;
+import apps.sarafrika.elimika.course.util.enums.SubmissionStatus;
+import apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException;
+import apps.sarafrika.elimika.shared.security.DomainSecurityService;
+import apps.sarafrika.elimika.shared.utils.GenericSpecificationBuilder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AssignmentSubmissionServiceImplTest {
+
+    @Mock
+    private AssignmentSubmissionRepository assignmentSubmissionRepository;
+    @Mock
+    private AssignmentRepository assignmentRepository;
+    @Mock
+    private GenericSpecificationBuilder<AssignmentSubmission> specificationBuilder;
+    @Mock
+    private AssignmentMediaValidationService assignmentMediaValidationService;
+    @Mock
+    private CourseGradeBookService courseGradeBookService;
+    @Mock
+    private CourseEnrollmentRepository courseEnrollmentRepository;
+    @Mock
+    private LessonRepository lessonRepository;
+    @Mock
+    private DomainSecurityService domainSecurityService;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private AssignmentSubmissionServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new AssignmentSubmissionServiceImpl(
+                assignmentSubmissionRepository,
+                assignmentRepository,
+                specificationBuilder,
+                assignmentMediaValidationService,
+                courseGradeBookService,
+                courseEnrollmentRepository,
+                lessonRepository,
+                domainSecurityService,
+                eventPublisher
+        );
+    }
+
+    @Test
+    void submitAssignmentResolvesStudentUuidToActiveCourseEnrollment() {
+        UUID assignmentUuid = UUID.randomUUID();
+        UUID lessonUuid = UUID.randomUUID();
+        UUID courseUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        UUID enrollmentUuid = UUID.randomUUID();
+
+        stubAssignmentCourseAndEnrollment(assignmentUuid, lessonUuid, courseUuid,
+                activeEnrollment(enrollmentUuid, studentUuid, courseUuid));
+        when(courseEnrollmentRepository.findByStudentUuidAndCourseUuid(studentUuid, courseUuid))
+                .thenReturn(Optional.of(activeEnrollment(enrollmentUuid, studentUuid, courseUuid)));
+        when(domainSecurityService.isStudentWithUuid(studentUuid)).thenReturn(true);
+        when(assignmentSubmissionRepository.findByEnrollmentUuidAndAssignmentUuid(enrollmentUuid, assignmentUuid))
+                .thenReturn(Optional.empty());
+        when(assignmentSubmissionRepository.save(any(AssignmentSubmission.class)))
+                .thenAnswer(invocation -> savedSubmission(invocation.getArgument(0)));
+
+        service.submitAssignment(
+                assignmentUuid,
+                new AssignmentSubmissionRequest(null, studentUuid, "Resolved by student", null),
+                false
+        );
+
+        ArgumentCaptor<AssignmentSubmission> submissionCaptor = ArgumentCaptor.forClass(AssignmentSubmission.class);
+        verify(assignmentSubmissionRepository).save(submissionCaptor.capture());
+        assertThat(submissionCaptor.getValue().getEnrollmentUuid()).isEqualTo(enrollmentUuid);
+        assertThat(submissionCaptor.getValue().getAssignmentUuid()).isEqualTo(assignmentUuid);
+        assertThat(submissionCaptor.getValue().getStatus()).isEqualTo(SubmissionStatus.SUBMITTED);
+
+        verify(eventPublisher).publishEvent(any(AssessmentCompletedNotificationRequestedEvent.class));
+    }
+
+    @Test
+    void submitAssignmentRejectsClassEnrollmentUuidBeforePersisting() {
+        UUID assignmentUuid = UUID.randomUUID();
+        UUID lessonUuid = UUID.randomUUID();
+        UUID courseUuid = UUID.randomUUID();
+        UUID classEnrollmentUuid = UUID.randomUUID();
+
+        stubAssignmentAndLesson(assignmentUuid, lessonUuid, courseUuid);
+        when(courseEnrollmentRepository.findByUuid(classEnrollmentUuid)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.submitAssignment(
+                assignmentUuid,
+                new AssignmentSubmissionRequest(classEnrollmentUuid, null, "Content", null),
+                false
+        ))
+                .isInstanceOf(ResourceNotFoundException.class)
+                .hasMessageContaining("Course enrollment with ID");
+
+        verify(assignmentSubmissionRepository, never()).save(any());
+    }
+
+    @Test
+    void submitAssignmentRejectsInactiveCourseEnrollment() {
+        UUID assignmentUuid = UUID.randomUUID();
+        UUID lessonUuid = UUID.randomUUID();
+        UUID courseUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        UUID enrollmentUuid = UUID.randomUUID();
+
+        stubAssignmentCourseAndEnrollment(assignmentUuid, lessonUuid, courseUuid,
+                enrollment(enrollmentUuid, studentUuid, courseUuid, EnrollmentStatus.COMPLETED));
+
+        assertThatThrownBy(() -> service.submitAssignment(
+                assignmentUuid,
+                new AssignmentSubmissionRequest(enrollmentUuid, null, "Content", null),
+                false
+        ))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Course enrollment must be active");
+
+        verify(assignmentSubmissionRepository, never()).save(any());
+    }
+
+    @Test
+    void submitAssignmentResubmitsReturnedSubmissionAndClearsGradeFields() {
+        UUID assignmentUuid = UUID.randomUUID();
+        UUID lessonUuid = UUID.randomUUID();
+        UUID courseUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        UUID enrollmentUuid = UUID.randomUUID();
+        AssignmentSubmission existing = existingSubmission(enrollmentUuid, assignmentUuid, SubmissionStatus.RETURNED);
+        existing.setScore(BigDecimal.valueOf(50));
+        existing.setMaxScore(BigDecimal.valueOf(100));
+        existing.setPercentage(BigDecimal.valueOf(50));
+        existing.setInstructorComments("Needs revision");
+        existing.setGradedByUuid(UUID.randomUUID());
+
+        stubAssignmentCourseAndEnrollment(assignmentUuid, lessonUuid, courseUuid,
+                activeEnrollment(enrollmentUuid, studentUuid, courseUuid));
+        when(domainSecurityService.isStudentWithUuid(studentUuid)).thenReturn(true);
+        when(assignmentSubmissionRepository.findByEnrollmentUuidAndAssignmentUuid(enrollmentUuid, assignmentUuid))
+                .thenReturn(Optional.of(existing));
+        when(assignmentSubmissionRepository.save(any(AssignmentSubmission.class)))
+                .thenAnswer(invocation -> savedSubmission(invocation.getArgument(0)));
+
+        service.submitAssignment(
+                assignmentUuid,
+                new AssignmentSubmissionRequest(enrollmentUuid, null, "Revised work", new String[]{"https://example.test/revised.pdf"}),
+                false
+        );
+
+        ArgumentCaptor<AssignmentSubmission> submissionCaptor = ArgumentCaptor.forClass(AssignmentSubmission.class);
+        verify(assignmentSubmissionRepository).save(submissionCaptor.capture());
+        AssignmentSubmission saved = submissionCaptor.getValue();
+        assertThat(saved).isSameAs(existing);
+        assertThat(saved.getStatus()).isEqualTo(SubmissionStatus.SUBMITTED);
+        assertThat(saved.getSubmissionText()).isEqualTo("Revised work");
+        assertThat(saved.getFileUrls()).containsExactly("https://example.test/revised.pdf");
+        assertThat(saved.getScore()).isNull();
+        assertThat(saved.getMaxScore()).isNull();
+        assertThat(saved.getPercentage()).isNull();
+        assertThat(saved.getInstructorComments()).isNull();
+        assertThat(saved.getGradedByUuid()).isNull();
+    }
+
+    @Test
+    void submitAssignmentRejectsDuplicateSubmittedSubmission() {
+        UUID assignmentUuid = UUID.randomUUID();
+        UUID lessonUuid = UUID.randomUUID();
+        UUID courseUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        UUID enrollmentUuid = UUID.randomUUID();
+
+        stubAssignmentCourseAndEnrollment(assignmentUuid, lessonUuid, courseUuid,
+                activeEnrollment(enrollmentUuid, studentUuid, courseUuid));
+        when(domainSecurityService.isStudentWithUuid(studentUuid)).thenReturn(true);
+        when(assignmentSubmissionRepository.findByEnrollmentUuidAndAssignmentUuid(enrollmentUuid, assignmentUuid))
+                .thenReturn(Optional.of(existingSubmission(enrollmentUuid, assignmentUuid, SubmissionStatus.SUBMITTED)));
+
+        assertThatThrownBy(() -> service.submitAssignment(
+                assignmentUuid,
+                new AssignmentSubmissionRequest(enrollmentUuid, null, "Duplicate", null),
+                false
+        ))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("already submitted");
+
+        verify(assignmentSubmissionRepository, never()).save(any());
+    }
+
+    @Test
+    void submitAssignmentRejectsUnpublishedAssignment() {
+        UUID assignmentUuid = UUID.randomUUID();
+        Assignment assignment = assignment(assignmentUuid, UUID.randomUUID(), false);
+        when(assignmentRepository.findByUuid(assignmentUuid)).thenReturn(Optional.of(assignment));
+
+        assertThatThrownBy(() -> service.submitAssignment(
+                assignmentUuid,
+                new AssignmentSubmissionRequest(UUID.randomUUID(), null, "Content", null),
+                false
+        ))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("not published");
+
+        verify(assignmentSubmissionRepository, never()).save(any());
+    }
+
+    @Test
+    void submitAssignmentPassesUploadedFilesFlagToValidation() {
+        UUID assignmentUuid = UUID.randomUUID();
+        UUID lessonUuid = UUID.randomUUID();
+        UUID courseUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        UUID enrollmentUuid = UUID.randomUUID();
+        Assignment assignment = assignment(assignmentUuid, lessonUuid, true);
+        assignment.setSubmissionTypes(new String[]{"DOCUMENT"});
+
+        when(assignmentRepository.findByUuid(assignmentUuid)).thenReturn(Optional.of(assignment));
+        when(lessonRepository.findByUuid(lessonUuid)).thenReturn(Optional.of(lesson(lessonUuid, courseUuid)));
+        when(courseEnrollmentRepository.findByUuid(enrollmentUuid))
+                .thenReturn(Optional.of(activeEnrollment(enrollmentUuid, studentUuid, courseUuid)));
+        when(domainSecurityService.isStudentWithUuid(studentUuid)).thenReturn(true);
+        when(assignmentSubmissionRepository.findByEnrollmentUuidAndAssignmentUuid(enrollmentUuid, assignmentUuid))
+                .thenReturn(Optional.empty());
+        when(assignmentSubmissionRepository.save(any(AssignmentSubmission.class)))
+                .thenAnswer(invocation -> savedSubmission(invocation.getArgument(0)));
+
+        service.submitAssignment(
+                assignmentUuid,
+                new AssignmentSubmissionRequest(enrollmentUuid, null, null, null),
+                true
+        );
+
+        verify(assignmentMediaValidationService)
+                .validateSubmissionRequest(eq(new String[]{"DOCUMENT"}), eq(null), eq(null), eq(true));
+    }
+
+    private void stubAssignmentCourseAndEnrollment(UUID assignmentUuid,
+                                                   UUID lessonUuid,
+                                                   UUID courseUuid,
+                                                   CourseEnrollment enrollment) {
+        stubAssignmentAndLesson(assignmentUuid, lessonUuid, courseUuid);
+        when(courseEnrollmentRepository.findByUuid(enrollment.getUuid())).thenReturn(Optional.of(enrollment));
+    }
+
+    private void stubAssignmentAndLesson(UUID assignmentUuid, UUID lessonUuid, UUID courseUuid) {
+        when(assignmentRepository.findByUuid(assignmentUuid))
+                .thenReturn(Optional.of(assignment(assignmentUuid, lessonUuid, true)));
+        when(lessonRepository.findByUuid(lessonUuid)).thenReturn(Optional.of(lesson(lessonUuid, courseUuid)));
+    }
+
+    private Assignment assignment(UUID assignmentUuid, UUID lessonUuid, boolean published) {
+        Assignment assignment = new Assignment();
+        assignment.setUuid(assignmentUuid);
+        assignment.setLessonUuid(lessonUuid);
+        assignment.setTitle("Assignment");
+        assignment.setSubmissionTypes(new String[]{"TEXT"});
+        assignment.setIsPublished(published);
+        return assignment;
+    }
+
+    private Lesson lesson(UUID lessonUuid, UUID courseUuid) {
+        Lesson lesson = new Lesson();
+        lesson.setUuid(lessonUuid);
+        lesson.setCourseUuid(courseUuid);
+        return lesson;
+    }
+
+    private CourseEnrollment activeEnrollment(UUID enrollmentUuid, UUID studentUuid, UUID courseUuid) {
+        return enrollment(enrollmentUuid, studentUuid, courseUuid, EnrollmentStatus.ACTIVE);
+    }
+
+    private CourseEnrollment enrollment(UUID enrollmentUuid,
+                                        UUID studentUuid,
+                                        UUID courseUuid,
+                                        EnrollmentStatus status) {
+        CourseEnrollment enrollment = new CourseEnrollment();
+        enrollment.setUuid(enrollmentUuid);
+        enrollment.setStudentUuid(studentUuid);
+        enrollment.setCourseUuid(courseUuid);
+        enrollment.setStatus(status);
+        return enrollment;
+    }
+
+    private AssignmentSubmission existingSubmission(UUID enrollmentUuid,
+                                                    UUID assignmentUuid,
+                                                    SubmissionStatus status) {
+        AssignmentSubmission submission = new AssignmentSubmission();
+        submission.setUuid(UUID.randomUUID());
+        submission.setEnrollmentUuid(enrollmentUuid);
+        submission.setAssignmentUuid(assignmentUuid);
+        submission.setStatus(status);
+        return submission;
+    }
+
+    private AssignmentSubmission savedSubmission(AssignmentSubmission submission) {
+        if (submission.getUuid() == null) {
+            submission.setUuid(UUID.randomUUID());
+        }
+        return submission;
+    }
+}


### PR DESCRIPTION
## Summary
- Repair the student assignment submission endpoint so learners can submit assignments using JSON, form or query parameters, or multipart file uploads.
- Validate submissions against the correct course enrollment and support returned assignment resubmissions.

## Changes
- Added an explicit AssignmentSubmissionRequest DTO with snake_case JSON fields.
- Updated POST /api/v1/assignments/{assignmentUuid}/submit to support JSON, multipart files, snake-case form/query parameters, and the legacy query contract.
- Enforced published assignment, active course enrollment, student ownership, and assignment-course matching before persistence.
- Allowed DRAFT and RETURNED submissions to be resubmitted while keeping SUBMITTED and GRADED duplicates blocked.
- Added submission attachment creation during multipart submit and tightened empty-submission validation.
- Added controller and service coverage for JSON submit, legacy submit, multipart file submit, enrollment validation, duplicate rejection, and returned resubmission.

## Tests
- JAVA_HOME=/home/willy/.jdks/temurin-21.0.11 ./gradlew test

## Configuration/Secret Impacts
- No configuration or secret changes.
- No database migration required.