### PR TITLE
feat: persist class session templates for schedule editing

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/classes/controller/ClassDefinitionController.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/controller/ClassDefinitionController.java
@@ -1,8 +1,11 @@
 package apps.sarafrika.elimika.classes.controller;
 
-import apps.sarafrika.elimika.classes.dto.ClassDefinitionDTO;
+import apps.sarafrika.elimika.classes.dto.ClassDefinitionCreateRequestDTO;
 import apps.sarafrika.elimika.classes.dto.ClassDefinitionResponseDTO;
+import apps.sarafrika.elimika.classes.dto.ClassDefinitionUpdateRequestDTO;
 import apps.sarafrika.elimika.classes.dto.ClassSchedulingConflictDTO;
+import apps.sarafrika.elimika.classes.dto.ClassSessionTemplateDTO;
+import apps.sarafrika.elimika.classes.dto.ClassSessionTemplateScheduleResponseDTO;
 import apps.sarafrika.elimika.classes.exception.SchedulingConflictException;
 import apps.sarafrika.elimika.classes.service.ClassDefinitionServiceInterface;
 import apps.sarafrika.elimika.shared.dto.ApiResponse;
@@ -45,11 +48,11 @@ public class ClassDefinitionController {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid input data")
     @PostMapping
     public ResponseEntity<ApiResponse<ClassDefinitionResponseDTO>> createClassDefinition(
-            @Valid @RequestBody ClassDefinitionDTO request) {
+            @Valid @RequestBody ClassDefinitionCreateRequestDTO request) {
         log.debug("REST request to create class definition: {}", request.title());
 
         try {
-            ClassDefinitionResponseDTO result = classDefinitionService.createClassDefinition(request);
+            ClassDefinitionResponseDTO result = classDefinitionService.createClassDefinition(request.toClassDefinitionDTO());
             return ResponseEntity.status(201).body(ApiResponse.success(result, "Class definition created successfully"));
         } catch (SchedulingConflictException e) {
             log.warn("Scheduling conflicts while creating class definition {}: {}", request.title(), e.getMessage());
@@ -64,7 +67,7 @@ public class ClassDefinitionController {
     public ResponseEntity<ApiResponse<ClassDefinitionResponseDTO>> createClassDefinitionForProgram(
             @Parameter(description = "UUID of the training program", required = true)
             @PathVariable UUID programUuid,
-            @Valid @RequestBody ClassDefinitionDTO request) {
+            @Valid @RequestBody ClassDefinitionCreateRequestDTO request) {
         log.debug("REST request to create class definition: {} for training program: {}", request.title(), programUuid);
 
         if (request.courseUuid() != null) {
@@ -72,42 +75,9 @@ public class ClassDefinitionController {
                     "course_uuid is not allowed when creating a class under /api/v1/classes/program/{programUuid}"));
         }
 
-        ClassDefinitionDTO programScopedRequest = new ClassDefinitionDTO(
-                request.uuid(),
-                request.title(),
-                request.description(),
-                request.defaultInstructorUuid(),
-                request.organisationUuid(),
-                null,
-                programUuid,
-                request.trainingFee(),
-                request.classVisibility(),
-                request.sessionFormat(),
-                request.defaultStartTime(),
-                request.defaultEndTime(),
-                request.academicPeriodStartDate(),
-                request.academicPeriodEndDate(),
-                request.registrationPeriodStartDate(),
-                request.registrationPeriodEndDate(),
-                request.classReminderMinutes(),
-                request.classColor(),
-                request.locationType(),
-                request.locationName(),
-                request.locationLatitude(),
-                request.locationLongitude(),
-                request.meetingLink(),
-                request.maxParticipants(),
-                request.allowWaitlist(),
-                request.isActive(),
-                request.sessionTemplates(),
-                request.createdDate(),
-                request.updatedDate(),
-                request.createdBy(),
-                request.updatedBy()
-        );
-
         try {
-            ClassDefinitionResponseDTO result = classDefinitionService.createClassDefinition(programScopedRequest);
+            ClassDefinitionResponseDTO result = classDefinitionService.createClassDefinition(
+                    request.toClassDefinitionDTO(null, programUuid));
             return ResponseEntity.status(201).body(ApiResponse.success(result, "Class definition created successfully"));
         } catch (SchedulingConflictException e) {
             log.warn("Scheduling conflicts while creating class definition {} for program {}: {}",
@@ -149,11 +119,32 @@ public class ClassDefinitionController {
     public ResponseEntity<ApiResponse<ClassDefinitionResponseDTO>> updateClassDefinition(
             @Parameter(description = "UUID of the class definition to update", required = true)
             @PathVariable UUID uuid,
-            @Valid @RequestBody ClassDefinitionDTO request) {
+            @Valid @RequestBody ClassDefinitionUpdateRequestDTO request) {
         log.debug("REST request to update class definition: {}", uuid);
         
-        ClassDefinitionResponseDTO result = classDefinitionService.updateClassDefinition(uuid, request);
+        ClassDefinitionResponseDTO result = classDefinitionService.updateClassDefinition(uuid, request.toClassDefinitionDTO());
         return ResponseEntity.ok(ApiResponse.success(result, "Class definition updated successfully"));
+    }
+
+    @Operation(summary = "Add a session template to an existing class definition")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "Class session template applied successfully")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid session template")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Class definition not found")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "409", description = "Scheduling conflicts detected")
+    @PostMapping("/{uuid}/session-templates")
+    public ResponseEntity<ApiResponse<ClassSessionTemplateScheduleResponseDTO>> addSessionTemplate(
+            @Parameter(description = "UUID of the class definition", required = true)
+            @PathVariable UUID uuid,
+            @Valid @RequestBody ClassSessionTemplateDTO request) {
+        log.debug("REST request to add session template to class definition: {}", uuid);
+
+        try {
+            ClassSessionTemplateScheduleResponseDTO result = classDefinitionService.addSessionTemplate(uuid, request);
+            return ResponseEntity.status(201).body(ApiResponse.success(result, "Class session template applied successfully"));
+        } catch (SchedulingConflictException e) {
+            log.warn("Scheduling conflicts while adding session template to class definition {}: {}", uuid, e.getMessage());
+            return ResponseEntity.status(409).body(ApiResponse.error("Scheduling conflicts detected", e.getConflicts()));
+        }
     }
 
     @Operation(summary = "Deactivate a class definition by UUID")

--- a/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionCreateRequestDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionCreateRequestDTO.java
@@ -1,0 +1,211 @@
+package apps.sarafrika.elimika.classes.dto;
+
+import apps.sarafrika.elimika.shared.enums.ClassVisibility;
+import apps.sarafrika.elimika.shared.enums.LocationType;
+import apps.sarafrika.elimika.shared.enums.SessionFormat;
+import apps.sarafrika.elimika.shared.validation.ValidTimeRange;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Schema(
+        name = "ClassDefinitionCreateRequest",
+        description = "Request payload for creating a class definition and its initial schedule templates"
+)
+@ValidTimeRange(
+        startField = "defaultStartTime",
+        endField = "defaultEndTime",
+        message = "Class end time must be after start time"
+)
+@ValidTimeRange(
+        startField = "academicPeriodStartDate",
+        endField = "academicPeriodEndDate",
+        allowEqual = true,
+        message = "Academic period end date must be on or after start date"
+)
+@ValidTimeRange(
+        startField = "registrationPeriodStartDate",
+        endField = "registrationPeriodEndDate",
+        allowEqual = true,
+        message = "Registration period end date must be on or after start date"
+)
+public record ClassDefinitionCreateRequestDTO(
+
+        @Schema(description = "**[REQUIRED]** Title of the class definition.", example = "Introduction to Java Programming")
+        @NotBlank(message = "Class title is required")
+        @Size(max = 255, message = "Title must not exceed 255 characters")
+        @JsonProperty("title")
+        String title,
+
+        @Schema(description = "**[OPTIONAL]** Detailed description of the class.", maxLength = 2000)
+        @Size(max = 2000, message = "Description must not exceed 2000 characters")
+        @JsonProperty("description")
+        String description,
+
+        @Schema(description = "**[REQUIRED]** Default instructor UUID for the class.")
+        @NotNull(message = "Default instructor UUID is required")
+        @JsonProperty("default_instructor_uuid")
+        UUID defaultInstructorUuid,
+
+        @Schema(description = "**[OPTIONAL]** Organisation UUID that owns the class.")
+        @JsonProperty("organisation_uuid")
+        UUID organisationUuid,
+
+        @Schema(description = "**[OPTIONAL]** Course UUID for course-scoped classes.")
+        @JsonProperty("course_uuid")
+        UUID courseUuid,
+
+        @Schema(description = "**[OPTIONAL]** Program UUID for program-scoped classes.")
+        @JsonProperty("program_uuid")
+        UUID programUuid,
+
+        @Schema(description = "**[OPTIONAL]** Training fee for the class.", minimum = "0")
+        @DecimalMin(value = "0.00", message = "Training fee cannot be negative")
+        @JsonProperty("training_fee")
+        BigDecimal trainingFee,
+
+        @Schema(description = "**[REQUIRED]** Class visibility.", allowableValues = {"PUBLIC", "PRIVATE"})
+        @NotNull(message = "Class visibility is required")
+        @JsonProperty("class_visibility")
+        ClassVisibility classVisibility,
+
+        @Schema(description = "**[REQUIRED]** Session format.", allowableValues = {"INDIVIDUAL", "GROUP"})
+        @NotNull(message = "Session format is required")
+        @JsonProperty("session_format")
+        SessionFormat sessionFormat,
+
+        @Schema(description = "**[REQUIRED]** Default start date-time for the class.", format = "date-time")
+        @NotNull(message = "Default start time is required")
+        @JsonProperty("default_start_time")
+        LocalDateTime defaultStartTime,
+
+        @Schema(description = "**[REQUIRED]** Default end date-time for the class.", format = "date-time")
+        @NotNull(message = "Default end time is required")
+        @JsonProperty("default_end_time")
+        LocalDateTime defaultEndTime,
+
+        @Schema(description = "**[OPTIONAL]** Academic period start date.", format = "date")
+        @JsonProperty("academic_period_start_date")
+        LocalDate academicPeriodStartDate,
+
+        @Schema(description = "**[OPTIONAL]** Academic period end date.", format = "date")
+        @JsonProperty("academic_period_end_date")
+        LocalDate academicPeriodEndDate,
+
+        @Schema(description = "**[OPTIONAL]** Registration period start date.", format = "date")
+        @JsonProperty("registration_period_start_date")
+        LocalDate registrationPeriodStartDate,
+
+        @Schema(description = "**[OPTIONAL]** Registration period end date.", format = "date")
+        @JsonProperty("registration_period_end_date")
+        LocalDate registrationPeriodEndDate,
+
+        @Schema(description = "**[OPTIONAL]** Reminder lead time in minutes.", minimum = "0")
+        @PositiveOrZero(message = "Class reminder minutes cannot be negative")
+        @JsonProperty("class_reminder_minutes")
+        Integer classReminderMinutes,
+
+        @Schema(description = "**[OPTIONAL]** Hex color used in calendar UI.", example = "#1F6FEB")
+        @Pattern(
+                regexp = "^#[0-9A-Fa-f]{6}$",
+                message = "Class color must be a valid hex color code in the format #RRGGBB"
+        )
+        @JsonProperty("class_color")
+        String classColor,
+
+        @Schema(description = "**[REQUIRED]** Delivery location type.", allowableValues = {"ONLINE", "IN_PERSON", "HYBRID"})
+        @NotNull(message = "Location type is required")
+        @JsonProperty("location_type")
+        LocationType locationType,
+
+        @Schema(description = "**[OPTIONAL]** Human-readable location name.")
+        @JsonProperty("location_name")
+        String locationName,
+
+        @Schema(description = "**[OPTIONAL]** Location latitude.")
+        @JsonProperty("location_latitude")
+        BigDecimal locationLatitude,
+
+        @Schema(description = "**[OPTIONAL]** Location longitude.")
+        @JsonProperty("location_longitude")
+        BigDecimal locationLongitude,
+
+        @Schema(description = "**[OPTIONAL]** Online meeting URL.", maxLength = 1000)
+        @Size(max = 1000, message = "Meeting link must not exceed 1000 characters")
+        @JsonProperty("meeting_link")
+        String meetingLink,
+
+        @Schema(description = "**[OPTIONAL]** Maximum participants.", minimum = "1")
+        @Positive(message = "Max participants must be positive")
+        @JsonProperty("max_participants")
+        Integer maxParticipants,
+
+        @Schema(description = "**[OPTIONAL]** Whether waitlisting is allowed.")
+        @JsonProperty("allow_waitlist")
+        Boolean allowWaitlist,
+
+        @Schema(description = "**[OPTIONAL]** Whether the class is active.")
+        @JsonProperty("is_active")
+        Boolean isActive,
+
+        @Schema(description = "**[REQUIRED]** Schedule templates used to generate initial scheduled sessions.")
+        @Valid
+        @NotNull(message = "session_templates is required")
+        @Size(min = 1, message = "At least one session template is required")
+        @JsonProperty("session_templates")
+        List<ClassSessionTemplateDTO> sessionTemplates
+) {
+
+    public ClassDefinitionDTO toClassDefinitionDTO() {
+        return toClassDefinitionDTO(courseUuid, programUuid);
+    }
+
+    public ClassDefinitionDTO toClassDefinitionDTO(UUID effectiveCourseUuid, UUID effectiveProgramUuid) {
+        return new ClassDefinitionDTO(
+                null,
+                title,
+                description,
+                defaultInstructorUuid,
+                organisationUuid,
+                effectiveCourseUuid,
+                effectiveProgramUuid,
+                trainingFee,
+                classVisibility,
+                sessionFormat,
+                defaultStartTime,
+                defaultEndTime,
+                academicPeriodStartDate,
+                academicPeriodEndDate,
+                registrationPeriodStartDate,
+                registrationPeriodEndDate,
+                classReminderMinutes,
+                classColor,
+                locationType,
+                locationName,
+                locationLatitude,
+                locationLongitude,
+                meetingLink,
+                maxParticipants,
+                allowWaitlist,
+                isActive,
+                sessionTemplates,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionDTO.java
@@ -374,17 +374,16 @@ public record ClassDefinitionDTO(
 
         @Schema(
                 description = """
-                        **[REQUIRED]** Inline session templates with time slots and recurrence rules to schedule class instances during creation.
+                        **[READ-ONLY]** Persisted session templates originally used to generate scheduled class instances.
+                        Legacy classes created before template persistence may return an empty list.
                         conflict_resolution per template:
                         - FAIL: stop scheduling if any conflict; response 409 with conflicts.
                         - SKIP: schedule non-conflicting occurrences; return conflicts for skipped dates.
                         - ROLLOVER: push conflicting dates forward by the recurrence interval (bounded retries) and extend the series; return unrecoverable conflicts.
                         """,
-                requiredMode = Schema.RequiredMode.REQUIRED
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
         )
-        @JsonProperty("session_templates")
-        @NotNull(message = "session_templates is required")
-        @Size(min = 1, message = "At least one session template is required")
+        @JsonProperty(value = "session_templates", access = JsonProperty.Access.READ_ONLY)
         List<ClassSessionTemplateDTO> sessionTemplates,
 
         @Schema(
@@ -559,6 +558,45 @@ public record ClassDefinitionDTO(
                 scheduledSessions,
                 completedSessions,
                 progressPercentage != null ? progressPercentage : BigDecimal.ZERO,
+                createdDate,
+                updatedDate,
+                createdBy,
+                updatedBy
+        );
+    }
+
+    public ClassDefinitionDTO withSessionTemplates(List<ClassSessionTemplateDTO> persistedSessionTemplates) {
+        return new ClassDefinitionDTO(
+                uuid,
+                title,
+                description,
+                defaultInstructorUuid,
+                organisationUuid,
+                courseUuid,
+                programUuid,
+                trainingFee,
+                classVisibility,
+                sessionFormat,
+                defaultStartTime,
+                defaultEndTime,
+                academicPeriodStartDate,
+                academicPeriodEndDate,
+                registrationPeriodStartDate,
+                registrationPeriodEndDate,
+                classReminderMinutes,
+                classColor,
+                locationType,
+                locationName,
+                locationLatitude,
+                locationLongitude,
+                meetingLink,
+                maxParticipants,
+                allowWaitlist,
+                isActive,
+                persistedSessionTemplates == null ? List.of() : persistedSessionTemplates,
+                scheduledSessionCount,
+                completedSessionCount,
+                classProgressPercentage,
                 createdDate,
                 updatedDate,
                 createdBy,

--- a/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionUpdateRequestDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionUpdateRequestDTO.java
@@ -1,0 +1,198 @@
+package apps.sarafrika.elimika.classes.dto;
+
+import apps.sarafrika.elimika.shared.enums.ClassVisibility;
+import apps.sarafrika.elimika.shared.enums.LocationType;
+import apps.sarafrika.elimika.shared.enums.SessionFormat;
+import apps.sarafrika.elimika.shared.validation.ValidTimeRange;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(
+        name = "ClassDefinitionUpdateRequest",
+        description = "Request payload for updating class metadata. Schedule changes use dedicated schedule endpoints."
+)
+@ValidTimeRange(
+        startField = "defaultStartTime",
+        endField = "defaultEndTime",
+        message = "Class end time must be after start time"
+)
+@ValidTimeRange(
+        startField = "academicPeriodStartDate",
+        endField = "academicPeriodEndDate",
+        allowEqual = true,
+        message = "Academic period end date must be on or after start date"
+)
+@ValidTimeRange(
+        startField = "registrationPeriodStartDate",
+        endField = "registrationPeriodEndDate",
+        allowEqual = true,
+        message = "Registration period end date must be on or after start date"
+)
+public record ClassDefinitionUpdateRequestDTO(
+
+        @Schema(description = "**[REQUIRED]** Title of the class definition.", example = "Introduction to Java Programming")
+        @NotBlank(message = "Class title is required")
+        @Size(max = 255, message = "Title must not exceed 255 characters")
+        @JsonProperty("title")
+        String title,
+
+        @Schema(description = "**[OPTIONAL]** Detailed description of the class.", maxLength = 2000)
+        @Size(max = 2000, message = "Description must not exceed 2000 characters")
+        @JsonProperty("description")
+        String description,
+
+        @Schema(description = "**[REQUIRED]** Default instructor UUID for the class.")
+        @NotNull(message = "Default instructor UUID is required")
+        @JsonProperty("default_instructor_uuid")
+        UUID defaultInstructorUuid,
+
+        @Schema(description = "**[OPTIONAL]** Organisation UUID that owns the class.")
+        @JsonProperty("organisation_uuid")
+        UUID organisationUuid,
+
+        @Schema(description = "**[OPTIONAL]** Course UUID for course-scoped classes.")
+        @JsonProperty("course_uuid")
+        UUID courseUuid,
+
+        @Schema(description = "**[OPTIONAL]** Program UUID for program-scoped classes.")
+        @JsonProperty("program_uuid")
+        UUID programUuid,
+
+        @Schema(description = "**[OPTIONAL]** Training fee for the class.", minimum = "0")
+        @DecimalMin(value = "0.00", message = "Training fee cannot be negative")
+        @JsonProperty("training_fee")
+        BigDecimal trainingFee,
+
+        @Schema(description = "**[REQUIRED]** Class visibility.", allowableValues = {"PUBLIC", "PRIVATE"})
+        @NotNull(message = "Class visibility is required")
+        @JsonProperty("class_visibility")
+        ClassVisibility classVisibility,
+
+        @Schema(description = "**[REQUIRED]** Session format.", allowableValues = {"INDIVIDUAL", "GROUP"})
+        @NotNull(message = "Session format is required")
+        @JsonProperty("session_format")
+        SessionFormat sessionFormat,
+
+        @Schema(description = "**[REQUIRED]** Default start date-time for the class.", format = "date-time")
+        @NotNull(message = "Default start time is required")
+        @JsonProperty("default_start_time")
+        LocalDateTime defaultStartTime,
+
+        @Schema(description = "**[REQUIRED]** Default end date-time for the class.", format = "date-time")
+        @NotNull(message = "Default end time is required")
+        @JsonProperty("default_end_time")
+        LocalDateTime defaultEndTime,
+
+        @Schema(description = "**[OPTIONAL]** Academic period start date.", format = "date")
+        @JsonProperty("academic_period_start_date")
+        LocalDate academicPeriodStartDate,
+
+        @Schema(description = "**[OPTIONAL]** Academic period end date.", format = "date")
+        @JsonProperty("academic_period_end_date")
+        LocalDate academicPeriodEndDate,
+
+        @Schema(description = "**[OPTIONAL]** Registration period start date.", format = "date")
+        @JsonProperty("registration_period_start_date")
+        LocalDate registrationPeriodStartDate,
+
+        @Schema(description = "**[OPTIONAL]** Registration period end date.", format = "date")
+        @JsonProperty("registration_period_end_date")
+        LocalDate registrationPeriodEndDate,
+
+        @Schema(description = "**[OPTIONAL]** Reminder lead time in minutes.", minimum = "0")
+        @PositiveOrZero(message = "Class reminder minutes cannot be negative")
+        @JsonProperty("class_reminder_minutes")
+        Integer classReminderMinutes,
+
+        @Schema(description = "**[OPTIONAL]** Hex color used in calendar UI.", example = "#1F6FEB")
+        @Pattern(
+                regexp = "^#[0-9A-Fa-f]{6}$",
+                message = "Class color must be a valid hex color code in the format #RRGGBB"
+        )
+        @JsonProperty("class_color")
+        String classColor,
+
+        @Schema(description = "**[REQUIRED]** Delivery location type.", allowableValues = {"ONLINE", "IN_PERSON", "HYBRID"})
+        @NotNull(message = "Location type is required")
+        @JsonProperty("location_type")
+        LocationType locationType,
+
+        @Schema(description = "**[OPTIONAL]** Human-readable location name.")
+        @JsonProperty("location_name")
+        String locationName,
+
+        @Schema(description = "**[OPTIONAL]** Location latitude.")
+        @JsonProperty("location_latitude")
+        BigDecimal locationLatitude,
+
+        @Schema(description = "**[OPTIONAL]** Location longitude.")
+        @JsonProperty("location_longitude")
+        BigDecimal locationLongitude,
+
+        @Schema(description = "**[OPTIONAL]** Online meeting URL.", maxLength = 1000)
+        @Size(max = 1000, message = "Meeting link must not exceed 1000 characters")
+        @JsonProperty("meeting_link")
+        String meetingLink,
+
+        @Schema(description = "**[OPTIONAL]** Maximum participants.", minimum = "1")
+        @Positive(message = "Max participants must be positive")
+        @JsonProperty("max_participants")
+        Integer maxParticipants,
+
+        @Schema(description = "**[OPTIONAL]** Whether waitlisting is allowed.")
+        @JsonProperty("allow_waitlist")
+        Boolean allowWaitlist,
+
+        @Schema(description = "**[OPTIONAL]** Whether the class is active.")
+        @JsonProperty("is_active")
+        Boolean isActive
+) {
+
+    public ClassDefinitionDTO toClassDefinitionDTO() {
+        return new ClassDefinitionDTO(
+                null,
+                title,
+                description,
+                defaultInstructorUuid,
+                organisationUuid,
+                courseUuid,
+                programUuid,
+                trainingFee,
+                classVisibility,
+                sessionFormat,
+                defaultStartTime,
+                defaultEndTime,
+                academicPeriodStartDate,
+                academicPeriodEndDate,
+                registrationPeriodStartDate,
+                registrationPeriodEndDate,
+                classReminderMinutes,
+                classColor,
+                locationType,
+                locationName,
+                locationLatitude,
+                locationLongitude,
+                meetingLink,
+                maxParticipants,
+                allowWaitlist,
+                isActive,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/classes/dto/ClassSessionTemplateDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/dto/ClassSessionTemplateDTO.java
@@ -6,12 +6,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Schema(
         name = "ClassSessionTemplate",
         description = "Time slot template used during class creation to generate scheduled instances with optional recurrence"
 )
 public record ClassSessionTemplateDTO(
+
+        @Schema(description = "**[READ-ONLY]** Unique identifier for this persisted class session template.")
+        @JsonProperty(value = "uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID uuid,
 
         @Schema(description = "Start time for the first occurrence (UTC)", example = "2025-01-15T14:00:00")
         @NotNull(message = "Session start time is required")
@@ -31,4 +36,12 @@ public record ClassSessionTemplateDTO(
         @JsonProperty("conflict_resolution")
         ConflictResolutionStrategy conflictResolution
 ) {
+        public ClassSessionTemplateDTO(
+                LocalDateTime startTime,
+                LocalDateTime endTime,
+                ClassRecurrenceDTO recurrence,
+                ConflictResolutionStrategy conflictResolution
+        ) {
+                this(null, startTime, endTime, recurrence, conflictResolution);
+        }
 }

--- a/src/main/java/apps/sarafrika/elimika/classes/dto/ClassSessionTemplateScheduleResponseDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/dto/ClassSessionTemplateScheduleResponseDTO.java
@@ -1,0 +1,32 @@
+package apps.sarafrika.elimika.classes.dto;
+
+import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceDTO;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.UUID;
+
+@Schema(
+        name = "ClassSessionTemplateScheduleResponse",
+        description = "Result of adding a session template to an existing class schedule"
+)
+public record ClassSessionTemplateScheduleResponseDTO(
+
+        @Schema(description = "**[READ-ONLY]** Class definition that received the new template.")
+        @JsonProperty("class_definition_uuid")
+        UUID classDefinitionUuid,
+
+        @Schema(description = "**[READ-ONLY]** Persisted session template.")
+        @JsonProperty("session_template")
+        ClassSessionTemplateDTO sessionTemplate,
+
+        @Schema(description = "**[READ-ONLY]** Scheduled instances created from the template.")
+        @JsonProperty("scheduled_instances")
+        List<ScheduledInstanceDTO> scheduledInstances,
+
+        @Schema(description = "**[READ-ONLY]** Non-blocking conflicts recorded while applying the template.")
+        @JsonProperty("scheduling_conflicts")
+        List<ClassSchedulingConflictDTO> schedulingConflicts
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/classes/factory/ClassSessionTemplateFactory.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/factory/ClassSessionTemplateFactory.java
@@ -1,0 +1,78 @@
+package apps.sarafrika.elimika.classes.factory;
+
+import apps.sarafrika.elimika.classes.dto.ClassRecurrenceDTO;
+import apps.sarafrika.elimika.classes.dto.ClassSessionTemplateDTO;
+import apps.sarafrika.elimika.classes.model.ClassSessionTemplate;
+import apps.sarafrika.elimika.classes.util.enums.ClassRecurrenceType;
+import apps.sarafrika.elimika.classes.util.enums.ConflictResolutionStrategy;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ClassSessionTemplateFactory {
+
+    public static ClassSessionTemplateDTO toDTO(ClassSessionTemplate entity) {
+        if (entity == null) {
+            return null;
+        }
+        return new ClassSessionTemplateDTO(
+                entity.getUuid(),
+                entity.getStartTime(),
+                entity.getEndTime(),
+                toRecurrenceDTO(entity),
+                Optional.ofNullable(entity.getConflictResolution()).orElse(ConflictResolutionStrategy.FAIL)
+        );
+    }
+
+    public static List<ClassSessionTemplateDTO> toDTOList(List<ClassSessionTemplate> entities) {
+        if (entities == null) {
+            return List.of();
+        }
+        return entities.stream()
+                .map(ClassSessionTemplateFactory::toDTO)
+                .toList();
+    }
+
+    public static ClassSessionTemplate toEntity(UUID classDefinitionUuid,
+                                                ClassSessionTemplateDTO dto,
+                                                int templateOrder) {
+        if (dto == null) {
+            return null;
+        }
+        ClassSessionTemplate entity = new ClassSessionTemplate();
+        entity.setUuid(dto.uuid());
+        entity.setClassDefinitionUuid(classDefinitionUuid);
+        entity.setTemplateOrder(templateOrder);
+        entity.setStartTime(dto.startTime());
+        entity.setEndTime(dto.endTime());
+        if (dto.recurrence() != null && dto.recurrence().recurrenceType() != null) {
+            entity.setRecurrenceType(ClassRecurrenceType.fromValue(dto.recurrence().recurrenceType().name()));
+            entity.setIntervalValue(dto.recurrence().intervalValue());
+            entity.setDaysOfWeek(dto.recurrence().daysOfWeek());
+            entity.setDayOfMonth(dto.recurrence().dayOfMonth());
+            entity.setEndDate(dto.recurrence().endDate());
+            entity.setOccurrenceCount(dto.recurrence().occurrenceCount());
+        }
+        entity.setConflictResolution(Optional.ofNullable(dto.conflictResolution())
+                .orElse(ConflictResolutionStrategy.FAIL));
+        return entity;
+    }
+
+    private static ClassRecurrenceDTO toRecurrenceDTO(ClassSessionTemplate entity) {
+        if (entity.getRecurrenceType() == null) {
+            return null;
+        }
+        return new ClassRecurrenceDTO(
+                ClassRecurrenceDTO.RecurrenceType.valueOf(entity.getRecurrenceType().name()),
+                entity.getIntervalValue(),
+                entity.getDaysOfWeek(),
+                entity.getDayOfMonth(),
+                entity.getEndDate(),
+                entity.getOccurrenceCount()
+        );
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/classes/model/ClassSessionTemplate.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/model/ClassSessionTemplate.java
@@ -1,0 +1,63 @@
+package apps.sarafrika.elimika.classes.model;
+
+import apps.sarafrika.elimika.classes.util.converter.ClassRecurrenceTypeConverter;
+import apps.sarafrika.elimika.classes.util.converter.ConflictResolutionStrategyConverter;
+import apps.sarafrika.elimika.classes.util.enums.ClassRecurrenceType;
+import apps.sarafrika.elimika.classes.util.enums.ConflictResolutionStrategy;
+import apps.sarafrika.elimika.shared.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "class_session_templates")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClassSessionTemplate extends BaseEntity {
+
+    @Column(name = "class_definition_uuid")
+    private UUID classDefinitionUuid;
+
+    @Column(name = "template_order")
+    private Integer templateOrder;
+
+    @Column(name = "start_time")
+    private LocalDateTime startTime;
+
+    @Column(name = "end_time")
+    private LocalDateTime endTime;
+
+    @Column(name = "recurrence_type")
+    @Convert(converter = ClassRecurrenceTypeConverter.class)
+    private ClassRecurrenceType recurrenceType;
+
+    @Column(name = "interval_value")
+    private Integer intervalValue;
+
+    @Column(name = "days_of_week")
+    private String daysOfWeek;
+
+    @Column(name = "day_of_month")
+    private Integer dayOfMonth;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Column(name = "occurrence_count")
+    private Integer occurrenceCount;
+
+    @Column(name = "conflict_resolution")
+    @Convert(converter = ConflictResolutionStrategyConverter.class)
+    private ConflictResolutionStrategy conflictResolution;
+}

--- a/src/main/java/apps/sarafrika/elimika/classes/repository/ClassSessionTemplateRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/repository/ClassSessionTemplateRepository.java
@@ -1,0 +1,14 @@
+package apps.sarafrika.elimika.classes.repository;
+
+import apps.sarafrika.elimika.classes.model.ClassSessionTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ClassSessionTemplateRepository extends JpaRepository<ClassSessionTemplate, Long> {
+
+    List<ClassSessionTemplate> findByClassDefinitionUuidOrderByTemplateOrderAscCreatedDateAsc(UUID classDefinitionUuid);
+
+    long countByClassDefinitionUuid(UUID classDefinitionUuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/classes/service/ClassDefinitionServiceInterface.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/service/ClassDefinitionServiceInterface.java
@@ -3,6 +3,8 @@ package apps.sarafrika.elimika.classes.service;
 import apps.sarafrika.elimika.classes.dto.ClassDefinitionResponseDTO;
 import apps.sarafrika.elimika.classes.dto.ClassDefinitionDTO;
 import apps.sarafrika.elimika.classes.dto.ClassSchedulingConflictDTO;
+import apps.sarafrika.elimika.classes.dto.ClassSessionTemplateDTO;
+import apps.sarafrika.elimika.classes.dto.ClassSessionTemplateScheduleResponseDTO;
 import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -25,6 +27,8 @@ public interface ClassDefinitionServiceInterface {
     ClassDefinitionResponseDTO createClassDefinition(ClassDefinitionDTO classDefinition);
 
     ClassDefinitionResponseDTO updateClassDefinition(UUID definitionUuid, ClassDefinitionDTO classDefinition);
+
+    ClassSessionTemplateScheduleResponseDTO addSessionTemplate(UUID definitionUuid, ClassSessionTemplateDTO sessionTemplate);
 
     void deactivateClassDefinition(UUID definitionUuid);
 

--- a/src/main/java/apps/sarafrika/elimika/classes/service/impl/ClassDefinitionServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/service/impl/ClassDefinitionServiceImpl.java
@@ -3,10 +3,13 @@ package apps.sarafrika.elimika.classes.service.impl;
 import apps.sarafrika.elimika.availability.spi.AvailabilityService;
 import apps.sarafrika.elimika.classes.dto.*;
 import apps.sarafrika.elimika.classes.factory.ClassDefinitionFactory;
+import apps.sarafrika.elimika.classes.factory.ClassSessionTemplateFactory;
 import apps.sarafrika.elimika.classes.model.ClassSchedulingConflict;
 import apps.sarafrika.elimika.classes.model.ClassDefinition;
+import apps.sarafrika.elimika.classes.model.ClassSessionTemplate;
 import apps.sarafrika.elimika.classes.repository.ClassDefinitionRepository;
 import apps.sarafrika.elimika.classes.repository.ClassSchedulingConflictRepository;
+import apps.sarafrika.elimika.classes.repository.ClassSessionTemplateRepository;
 import apps.sarafrika.elimika.classes.service.ClassDefinitionServiceInterface;
 import apps.sarafrika.elimika.classes.spi.ClassDefinitionService;
 import apps.sarafrika.elimika.course.spi.CourseInfoService;
@@ -48,6 +51,7 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
 
     private final ClassDefinitionRepository classDefinitionRepository;
     private final ClassSchedulingConflictRepository classSchedulingConflictRepository;
+    private final ClassSessionTemplateRepository classSessionTemplateRepository;
     private final AvailabilityService availabilityService;
     private final ApplicationEventPublisher eventPublisher;
     private final CourseInfoService courseInfoService;
@@ -90,9 +94,13 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
         validateTrainingFee(entity);
 
         ClassDefinition savedEntity = classDefinitionRepository.save(entity);
-        ClassDefinitionDTO result = ClassDefinitionFactory.toDTO(savedEntity);
+        List<ClassSessionTemplateDTO> persistedTemplates = saveSessionTemplates(
+                savedEntity.getUuid(),
+                classDefinitionDTO.sessionTemplates());
+        ClassDefinitionDTO result = ClassDefinitionFactory.toDTO(savedEntity)
+                .withSessionTemplates(persistedTemplates);
 
-        ClassSchedulingOutcome schedulingOutcome = applySessionTemplates(result, classDefinitionDTO.sessionTemplates());
+        ClassSchedulingOutcome schedulingOutcome = applySessionTemplates(result, persistedTemplates);
         persistSchedulingConflicts(result.uuid(), schedulingOutcome.conflicts());
         if (schedulingOutcome.blockingConflict()) {
             throw new SchedulingConflictException(
@@ -117,6 +125,33 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
         
         log.info("Created class definition with UUID: {} and published ClassDefinedEvent", result.uuid());
         return buildResponse(result);
+    }
+
+    @Override
+    public ClassSessionTemplateScheduleResponseDTO addSessionTemplate(UUID definitionUuid,
+                                                                     ClassSessionTemplateDTO sessionTemplate) {
+        log.debug("Adding session template to class definition with UUID: {}", definitionUuid);
+
+        if (sessionTemplate == null) {
+            throw new IllegalArgumentException("Session template cannot be null");
+        }
+
+        ClassDefinitionDTO classDefinition = getClassDefinitionDTO(definitionUuid);
+        ClassSchedulingOutcome schedulingOutcome = applySessionTemplates(classDefinition, List.of(sessionTemplate));
+        persistSchedulingConflicts(definitionUuid, schedulingOutcome.conflicts());
+        if (schedulingOutcome.blockingConflict()) {
+            throw new SchedulingConflictException(
+                    String.format("Conflicts detected for class %s", classDefinition.title()),
+                    schedulingOutcome.conflicts());
+        }
+
+        ClassSessionTemplateDTO persistedTemplate = saveSessionTemplate(definitionUuid, sessionTemplate);
+        return new ClassSessionTemplateScheduleResponseDTO(
+                definitionUuid,
+                persistedTemplate,
+                schedulingOutcome.scheduledInstances(),
+                schedulingOutcome.conflicts()
+        );
     }
 
     private ClassSchedulingOutcome applySessionTemplates(ClassDefinitionDTO classDefinition,
@@ -545,9 +580,41 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
             throw new IllegalArgumentException("Class definition UUID cannot be null");
         }
         return classDefinitionRepository.findByUuid(classDefinitionUuid)
-                .map(ClassDefinitionFactory::toDTO)
+                .map(this::toDTOWithSessionTemplates)
                 .orElseThrow(() -> new ResourceNotFoundException(
                         String.format(CLASS_DEFINITION_NOT_FOUND_TEMPLATE, classDefinitionUuid)));
+    }
+
+    private ClassDefinitionDTO toDTOWithSessionTemplates(ClassDefinition entity) {
+        ClassDefinitionDTO dto = ClassDefinitionFactory.toDTO(entity);
+        if (dto == null || dto.uuid() == null) {
+            return dto;
+        }
+        return dto.withSessionTemplates(loadSessionTemplates(dto.uuid()));
+    }
+
+    private List<ClassSessionTemplateDTO> loadSessionTemplates(UUID classDefinitionUuid) {
+        return ClassSessionTemplateFactory.toDTOList(classSessionTemplateRepository
+                .findByClassDefinitionUuidOrderByTemplateOrderAscCreatedDateAsc(classDefinitionUuid));
+    }
+
+    private List<ClassSessionTemplateDTO> saveSessionTemplates(UUID classDefinitionUuid,
+                                                               List<ClassSessionTemplateDTO> sessionTemplates) {
+        if (sessionTemplates == null || sessionTemplates.isEmpty()) {
+            return List.of();
+        }
+        List<ClassSessionTemplate> entities = new ArrayList<>();
+        for (int i = 0; i < sessionTemplates.size(); i++) {
+            entities.add(ClassSessionTemplateFactory.toEntity(classDefinitionUuid, sessionTemplates.get(i), i));
+        }
+        return ClassSessionTemplateFactory.toDTOList(classSessionTemplateRepository.saveAll(entities));
+    }
+
+    private ClassSessionTemplateDTO saveSessionTemplate(UUID classDefinitionUuid,
+                                                        ClassSessionTemplateDTO sessionTemplate) {
+        int templateOrder = Math.toIntExact(classSessionTemplateRepository.countByClassDefinitionUuid(classDefinitionUuid));
+        ClassSessionTemplate entity = ClassSessionTemplateFactory.toEntity(classDefinitionUuid, sessionTemplate, templateOrder);
+        return ClassSessionTemplateFactory.toDTO(classSessionTemplateRepository.save(entity));
     }
 
     private void persistSchedulingConflicts(UUID classDefinitionUuid, List<ClassSchedulingConflictDTO> conflicts) {
@@ -587,7 +654,7 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
         validateTrainingFee(existingEntity);
         
         ClassDefinition savedEntity = classDefinitionRepository.save(existingEntity);
-        ClassDefinitionDTO result = ClassDefinitionFactory.toDTO(savedEntity);
+        ClassDefinitionDTO result = toDTOWithSessionTemplates(savedEntity);
         
         // Publish domain event
         ClassDefinitionUpdatedEventDTO event = new ClassDefinitionUpdatedEventDTO(
@@ -627,7 +694,7 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
         log.debug("Retrieving class definition with UUID: {}", definitionUuid);
 
         ClassDefinitionDTO classDefinition = classDefinitionRepository.findByUuid(definitionUuid)
-                .map(ClassDefinitionFactory::toDTO)
+                .map(this::toDTOWithSessionTemplates)
                 .orElseThrow(() -> new ResourceNotFoundException(String.format(CLASS_DEFINITION_NOT_FOUND_TEMPLATE, definitionUuid)));
         return buildResponse(classDefinition);
     }
@@ -639,7 +706,7 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
 
         return classDefinitionRepository.findByCourseUuid(courseUuid)
                 .stream()
-                .map(ClassDefinitionFactory::toDTO)
+                .map(this::toDTOWithSessionTemplates)
                 .map(this::buildResponse)
                 .collect(Collectors.toList());
     }
@@ -656,7 +723,7 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
 
         return classDefinitionRepository.findActiveClassesForCourse(courseUuid)
                 .stream()
-                .map(ClassDefinitionFactory::toDTO)
+                .map(this::toDTOWithSessionTemplates)
                 .map(this::buildResponse)
                 .collect(Collectors.toList());
     }
@@ -668,7 +735,7 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
 
         return classDefinitionRepository.findByProgramUuid(programUuid)
                 .stream()
-                .map(ClassDefinitionFactory::toDTO)
+                .map(this::toDTOWithSessionTemplates)
                 .map(this::buildResponse)
                 .collect(Collectors.toList());
     }
@@ -685,7 +752,7 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
 
         return classDefinitionRepository.findActiveClassesForProgram(programUuid)
                 .stream()
-                .map(ClassDefinitionFactory::toDTO)
+                .map(this::toDTOWithSessionTemplates)
                 .map(this::buildResponse)
                 .collect(Collectors.toList());
     }
@@ -697,7 +764,7 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
 
         return classDefinitionRepository.findByDefaultInstructorUuid(instructorUuid)
                 .stream()
-                .map(ClassDefinitionFactory::toDTO)
+                .map(this::toDTOWithSessionTemplates)
                 .map(this::buildResponse)
                 .collect(Collectors.toList());
     }
@@ -710,7 +777,7 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
         return classDefinitionRepository.findActiveClassesForInstructor(instructorUuid)
                 .stream()
                 .filter(this::isLinkedContentApproved)
-                .map(ClassDefinitionFactory::toDTO)
+                .map(this::toDTOWithSessionTemplates)
                 .map(this::buildResponse)
                 .collect(Collectors.toList());
     }
@@ -722,7 +789,7 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
 
         return classDefinitionRepository.findByOrganisationUuid(organisationUuid)
                 .stream()
-                .map(ClassDefinitionFactory::toDTO)
+                .map(this::toDTOWithSessionTemplates)
                 .map(this::buildResponse)
                 .collect(Collectors.toList());
     }
@@ -733,7 +800,7 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
         log.debug("Finding all classes (page: {}, size: {})", pageable.getPageNumber(), pageable.getPageSize());
 
         return classDefinitionRepository.findAll(pageable)
-                .map(ClassDefinitionFactory::toDTO)
+                .map(this::toDTOWithSessionTemplates)
                 .map(this::buildResponse);
     }
 
@@ -745,7 +812,7 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
         return classDefinitionRepository.findByIsActiveTrue()
                 .stream()
                 .filter(this::isLinkedContentApproved)
-                .map(ClassDefinitionFactory::toDTO)
+                .map(this::toDTOWithSessionTemplates)
                 .map(this::buildResponse)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/apps/sarafrika/elimika/classes/util/converter/ClassRecurrenceTypeConverter.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/util/converter/ClassRecurrenceTypeConverter.java
@@ -1,0 +1,21 @@
+package apps.sarafrika.elimika.classes.util.converter;
+
+import apps.sarafrika.elimika.classes.util.enums.ClassRecurrenceType;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Locale;
+
+@Converter(autoApply = true)
+public class ClassRecurrenceTypeConverter implements AttributeConverter<ClassRecurrenceType, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ClassRecurrenceType attribute) {
+        return attribute == null ? null : attribute.name().toUpperCase(Locale.ROOT);
+    }
+
+    @Override
+    public ClassRecurrenceType convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : ClassRecurrenceType.fromValue(dbData.toUpperCase(Locale.ROOT));
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/classes/util/converter/ConflictResolutionStrategyConverter.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/util/converter/ConflictResolutionStrategyConverter.java
@@ -1,0 +1,21 @@
+package apps.sarafrika.elimika.classes.util.converter;
+
+import apps.sarafrika.elimika.classes.util.enums.ConflictResolutionStrategy;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import java.util.Locale;
+
+@Converter(autoApply = true)
+public class ConflictResolutionStrategyConverter implements AttributeConverter<ConflictResolutionStrategy, String> {
+
+    @Override
+    public String convertToDatabaseColumn(ConflictResolutionStrategy attribute) {
+        return attribute == null ? null : attribute.name().toUpperCase(Locale.ROOT);
+    }
+
+    @Override
+    public ConflictResolutionStrategy convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : ConflictResolutionStrategy.valueOf(dbData.toUpperCase(Locale.ROOT));
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/classes/util/enums/ClassRecurrenceType.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/util/enums/ClassRecurrenceType.java
@@ -1,0 +1,25 @@
+package apps.sarafrika.elimika.classes.util.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Locale;
+
+public enum ClassRecurrenceType {
+    DAILY,
+    WEEKLY,
+    MONTHLY;
+
+    @JsonValue
+    public String getValue() {
+        return name();
+    }
+
+    @JsonCreator
+    public static ClassRecurrenceType fromValue(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return ClassRecurrenceType.valueOf(value.trim().toUpperCase(Locale.ROOT));
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/timetabling/controller/TimetableController.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/controller/TimetableController.java
@@ -3,6 +3,7 @@ package apps.sarafrika.elimika.timetabling.controller;
 import apps.sarafrika.elimika.shared.dto.ApiResponse;
 import apps.sarafrika.elimika.timetabling.dto.BlockInstructorTimeRequest;
 import apps.sarafrika.elimika.timetabling.spi.ScheduleRequestDTO;
+import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceRescheduleRequestDTO;
 import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceDTO;
 import apps.sarafrika.elimika.timetabling.spi.StudentScheduleDTO;
 import apps.sarafrika.elimika.timetabling.spi.TimetableService;
@@ -79,6 +80,21 @@ public class TimetableController {
         
         timetableService.updateScheduledInstanceStatus(instanceUuid, status);
         return ResponseEntity.ok(ApiResponse.success(null, "Status updated successfully"));
+    }
+
+    @Operation(summary = "Reschedule a scheduled class instance")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Scheduled instance rescheduled successfully")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid time range, scheduling conflict, or instance is not reschedulable")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Scheduled instance not found")
+    @PatchMapping("/schedule/{instanceUuid}/time")
+    public ResponseEntity<ApiResponse<ScheduledInstanceDTO>> rescheduleScheduledInstance(
+            @Parameter(description = "UUID of the scheduled instance")
+            @PathVariable UUID instanceUuid,
+            @Valid @RequestBody ScheduledInstanceRescheduleRequestDTO request) {
+        log.debug("REST request to reschedule scheduled instance: {}", instanceUuid);
+
+        ScheduledInstanceDTO result = timetableService.rescheduleScheduledInstance(instanceUuid, request);
+        return ResponseEntity.ok(ApiResponse.success(result, "Scheduled instance rescheduled successfully"));
     }
 
     @Operation(summary = "Start a scheduled class instance")

--- a/src/main/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImpl.java
@@ -23,6 +23,7 @@ import apps.sarafrika.elimika.timetabling.spi.StudentCourseEnrollmentSummaryDTO;
 import apps.sarafrika.elimika.timetabling.spi.StudentClassEnrollmentSummaryDTO;
 import apps.sarafrika.elimika.timetabling.spi.StudentScheduleDTO;
 import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceDTO;
+import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceRescheduleRequestDTO;
 import apps.sarafrika.elimika.timetabling.spi.ScheduleRequestDTO;
 import apps.sarafrika.elimika.timetabling.factory.EnrollmentFactory;
 import apps.sarafrika.elimika.timetabling.factory.ScheduledInstanceFactory;
@@ -183,6 +184,49 @@ public class TimetableServiceImpl implements TimetableService {
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("Invalid scheduling status: " + newStatus);
         }
+    }
+
+    @Override
+    public ScheduledInstanceDTO rescheduleScheduledInstance(UUID instanceUuid,
+                                                           ScheduledInstanceRescheduleRequestDTO request) {
+        log.debug("Rescheduling scheduled instance: {}", instanceUuid);
+
+        if (request == null) {
+            throw new IllegalArgumentException("Reschedule request cannot be null");
+        }
+
+        ScheduledInstance entity = findScheduledInstanceOrThrow(instanceUuid);
+        if (!SchedulingStatus.SCHEDULED.equals(entity.getStatus())) {
+            throw new IllegalArgumentException("Only scheduled instances can be rescheduled");
+        }
+
+        String timezone = request.timezone() == null || request.timezone().isBlank()
+                ? Optional.ofNullable(entity.getTimezone()).orElse("UTC")
+                : request.timezone().trim();
+        ScheduleRequestDTO scheduleRequest = new ScheduleRequestDTO(
+                entity.getClassDefinitionUuid(),
+                entity.getInstructorUuid(),
+                request.startTime(),
+                request.endTime(),
+                timezone
+        );
+
+        validateScheduleRequest(scheduleRequest);
+        List<String> conflicts = resolveInstructorConflicts(
+                entity.getInstructorUuid(),
+                scheduleRequest,
+                entity.getUuid());
+        if (!conflicts.isEmpty()) {
+            throw new IllegalArgumentException(String.join("; ", conflicts));
+        }
+
+        entity.setStartTime(request.startTime());
+        entity.setEndTime(request.endTime());
+        entity.setTimezone(timezone);
+
+        ScheduledInstance savedEntity = scheduledInstanceRepository.save(entity);
+        log.debug("Rescheduled instance {} to {} - {}", instanceUuid, request.startTime(), request.endTime());
+        return ScheduledInstanceFactory.toDTO(savedEntity);
     }
 
     @Override
@@ -1047,6 +1091,12 @@ public class TimetableServiceImpl implements TimetableService {
     }
 
     private List<String> resolveInstructorConflicts(UUID instructorUuid, ScheduleRequestDTO request) {
+        return resolveInstructorConflicts(instructorUuid, request, null);
+    }
+
+    private List<String> resolveInstructorConflicts(UUID instructorUuid,
+                                                    ScheduleRequestDTO request,
+                                                    UUID excludedInstanceUuid) {
         List<String> conflicts = new java.util.ArrayList<>();
 
         if (!availabilityService.isInstructorAvailable(instructorUuid, request.startTime(), request.endTime())) {
@@ -1054,7 +1104,10 @@ public class TimetableServiceImpl implements TimetableService {
         }
 
         List<ScheduledInstance> overlapping = scheduledInstanceRepository
-                .findOverlappingInstancesForInstructor(instructorUuid, request.startTime(), request.endTime());
+                .findOverlappingInstancesForInstructor(instructorUuid, request.startTime(), request.endTime())
+                .stream()
+                .filter(instance -> excludedInstanceUuid == null || !Objects.equals(instance.getUuid(), excludedInstanceUuid))
+                .toList();
         if (!overlapping.isEmpty()) {
             conflicts.add("Instructor has existing scheduled instances that overlap this time");
         }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/spi/ScheduledInstanceRescheduleRequestDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/spi/ScheduledInstanceRescheduleRequestDTO.java
@@ -1,0 +1,29 @@
+package apps.sarafrika.elimika.timetabling.spi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+@Schema(
+        name = "ScheduledInstanceRescheduleRequest",
+        description = "Request payload for changing the date and time of a scheduled class instance"
+)
+public record ScheduledInstanceRescheduleRequestDTO(
+
+        @Schema(description = "**[REQUIRED]** New start date and time for the scheduled instance.", format = "date-time")
+        @NotNull(message = "Start time is required")
+        @JsonProperty("start_time")
+        LocalDateTime startTime,
+
+        @Schema(description = "**[REQUIRED]** New end date and time for the scheduled instance.", format = "date-time")
+        @NotNull(message = "End time is required")
+        @JsonProperty("end_time")
+        LocalDateTime endTime,
+
+        @Schema(description = "**[OPTIONAL]** Timezone for the scheduled instance. Defaults to the existing timezone.")
+        @JsonProperty("timezone")
+        String timezone
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/timetabling/spi/TimetableService.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/spi/TimetableService.java
@@ -64,6 +64,17 @@ public interface TimetableService {
     void updateScheduledInstanceStatus(UUID instanceUuid, String newStatus);
 
     /**
+     * Reschedules a scheduled class instance while keeping the same UUID and enrollments.
+     *
+     * @param instanceUuid The UUID of the scheduled instance to reschedule
+     * @param request The new time window
+     * @return Updated scheduled instance
+     * @throws IllegalArgumentException if the request is invalid, conflicts exist, or the instance is not reschedulable
+     * @throws RuntimeException if scheduled instance is not found
+     */
+    ScheduledInstanceDTO rescheduleScheduledInstance(UUID instanceUuid, ScheduledInstanceRescheduleRequestDTO request);
+
+    /**
      * Explicitly starts a scheduled class instance and records the actual start timestamp.
      *
      * @param instanceUuid The UUID of the scheduled instance to start

--- a/src/main/resources/db/migration/V202606111648__create_class_session_templates.sql
+++ b/src/main/resources/db/migration/V202606111648__create_class_session_templates.sql
@@ -1,0 +1,46 @@
+CREATE TABLE class_session_templates
+(
+    id                    BIGSERIAL PRIMARY KEY,
+    uuid                  UUID                     NOT NULL DEFAULT gen_random_uuid() UNIQUE,
+    class_definition_uuid UUID                     NOT NULL REFERENCES class_definitions (uuid) ON DELETE CASCADE,
+    template_order        INTEGER                  NOT NULL,
+    start_time            TIMESTAMP WITH TIME ZONE NOT NULL,
+    end_time              TIMESTAMP WITH TIME ZONE NOT NULL,
+    recurrence_type       VARCHAR(32),
+    interval_value        INTEGER,
+    days_of_week          VARCHAR(128),
+    day_of_month          INTEGER,
+    end_date              DATE,
+    occurrence_count      INTEGER,
+    conflict_resolution   VARCHAR(32)              NOT NULL,
+    created_date          TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+    updated_date          TIMESTAMP WITH TIME ZONE,
+    created_by            VARCHAR(255)             NOT NULL,
+    updated_by            VARCHAR(255),
+    CONSTRAINT chk_class_session_templates_time_valid
+        CHECK (start_time < end_time),
+    CONSTRAINT chk_class_session_templates_template_order_non_negative
+        CHECK (template_order >= 0),
+    CONSTRAINT chk_class_session_templates_recurrence_type
+        CHECK (recurrence_type IS NULL OR recurrence_type IN ('DAILY', 'WEEKLY', 'MONTHLY')),
+    CONSTRAINT chk_class_session_templates_interval_positive
+        CHECK (interval_value IS NULL OR interval_value > 0),
+    CONSTRAINT chk_class_session_templates_day_of_month_valid
+        CHECK (day_of_month IS NULL OR day_of_month BETWEEN 1 AND 31),
+    CONSTRAINT chk_class_session_templates_occurrence_count_positive
+        CHECK (occurrence_count IS NULL OR occurrence_count > 0),
+    CONSTRAINT chk_class_session_templates_conflict_resolution
+        CHECK (conflict_resolution IN ('FAIL', 'SKIP', 'ROLLOVER')),
+    CONSTRAINT uq_class_session_templates_class_order
+        UNIQUE (class_definition_uuid, template_order)
+);
+
+CREATE INDEX idx_class_session_templates_class_definition
+    ON class_session_templates (class_definition_uuid);
+
+COMMENT ON TABLE class_session_templates IS 'Stores the original session templates used to generate scheduled instances for a class definition';
+COMMENT ON COLUMN class_session_templates.class_definition_uuid IS 'Class definition that owns this session template';
+COMMENT ON COLUMN class_session_templates.template_order IS 'Stable ordering of templates within the class definition payload';
+COMMENT ON COLUMN class_session_templates.start_time IS 'UTC start date-time for the first occurrence';
+COMMENT ON COLUMN class_session_templates.end_time IS 'UTC end date-time for the first occurrence';
+COMMENT ON COLUMN class_session_templates.conflict_resolution IS 'Conflict handling strategy used when applying this template';

--- a/src/test/java/apps/sarafrika/elimika/classes/controller/ClassDefinitionControllerTest.java
+++ b/src/test/java/apps/sarafrika/elimika/classes/controller/ClassDefinitionControllerTest.java
@@ -2,8 +2,10 @@ package apps.sarafrika.elimika.classes.controller;
 
 import apps.sarafrika.elimika.classes.dto.ClassDefinitionDTO;
 import apps.sarafrika.elimika.classes.dto.ClassDefinitionResponseDTO;
+import apps.sarafrika.elimika.classes.dto.ClassDefinitionUpdateRequestDTO;
 import apps.sarafrika.elimika.classes.dto.ClassRecurrenceDTO;
 import apps.sarafrika.elimika.classes.dto.ClassSessionTemplateDTO;
+import apps.sarafrika.elimika.classes.dto.ClassSessionTemplateScheduleResponseDTO;
 import apps.sarafrika.elimika.classes.service.ClassDefinitionServiceInterface;
 import apps.sarafrika.elimika.classes.util.enums.ConflictResolutionStrategy;
 import apps.sarafrika.elimika.shared.config.GlobalExceptionHandler;
@@ -37,11 +39,13 @@ import java.util.UUID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -113,6 +117,61 @@ class ClassDefinitionControllerTest {
         assertEquals(request.registrationPeriodEndDate(), forwarded.registrationPeriodEndDate());
         assertEquals(request.classReminderMinutes(), forwarded.classReminderMinutes());
         assertEquals(request.classColor(), forwarded.classColor());
+    }
+
+    @Test
+    void updateClassDefinitionDoesNotRequireSessionTemplates() throws Exception {
+        UUID classUuid = UUID.randomUUID();
+        ClassDefinitionDTO existing = sampleRequest(UUID.randomUUID(), null, 30, "#1F6FEB");
+        ClassDefinitionUpdateRequestDTO request = sampleUpdateRequest(existing);
+
+        when(classDefinitionService.updateClassDefinition(any(UUID.class), any(ClassDefinitionDTO.class)))
+                .thenReturn(new ClassDefinitionResponseDTO(existing));
+
+        mockMvc.perform(put("/api/v1/classes/{uuid}", classUuid)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.class_definition.title").value(existing.title()));
+
+        ArgumentCaptor<ClassDefinitionDTO> captor = ArgumentCaptor.forClass(ClassDefinitionDTO.class);
+        verify(classDefinitionService).updateClassDefinition(eq(classUuid), captor.capture());
+        assertNull(captor.getValue().sessionTemplates());
+    }
+
+    @Test
+    void addSessionTemplateAppliesTemplateToExistingClass() throws Exception {
+        UUID classUuid = UUID.randomUUID();
+        ClassSessionTemplateDTO request = new ClassSessionTemplateDTO(
+                LocalDateTime.of(2026, 5, 12, 9, 0),
+                LocalDateTime.of(2026, 5, 12, 11, 0),
+                null,
+                ConflictResolutionStrategy.FAIL
+        );
+        ClassSessionTemplateDTO persistedTemplate = new ClassSessionTemplateDTO(
+                UUID.randomUUID(),
+                request.startTime(),
+                request.endTime(),
+                request.recurrence(),
+                request.conflictResolution()
+        );
+
+        when(classDefinitionService.addSessionTemplate(eq(classUuid), any(ClassSessionTemplateDTO.class)))
+                .thenReturn(new ClassSessionTemplateScheduleResponseDTO(
+                        classUuid,
+                        persistedTemplate,
+                        List.of(),
+                        List.of()
+                ));
+
+        mockMvc.perform(post("/api/v1/classes/{uuid}/session-templates", classUuid)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.class_definition_uuid").value(classUuid.toString()))
+                .andExpect(jsonPath("$.data.session_template.uuid").value(persistedTemplate.uuid().toString()));
+
+        verify(classDefinitionService).addSessionTemplate(eq(classUuid), any(ClassSessionTemplateDTO.class));
     }
 
     @Test
@@ -264,6 +323,36 @@ class ClassDefinitionControllerTest {
                 null,
                 null,
                 null
+        );
+    }
+
+    private ClassDefinitionUpdateRequestDTO sampleUpdateRequest(ClassDefinitionDTO source) {
+        return new ClassDefinitionUpdateRequestDTO(
+                source.title(),
+                source.description(),
+                source.defaultInstructorUuid(),
+                source.organisationUuid(),
+                source.courseUuid(),
+                source.programUuid(),
+                source.trainingFee(),
+                source.classVisibility(),
+                source.sessionFormat(),
+                source.defaultStartTime(),
+                source.defaultEndTime(),
+                source.academicPeriodStartDate(),
+                source.academicPeriodEndDate(),
+                source.registrationPeriodStartDate(),
+                source.registrationPeriodEndDate(),
+                source.classReminderMinutes(),
+                source.classColor(),
+                source.locationType(),
+                source.locationName(),
+                source.locationLatitude(),
+                source.locationLongitude(),
+                source.meetingLink(),
+                source.maxParticipants(),
+                source.allowWaitlist(),
+                source.isActive()
         );
     }
 

--- a/src/test/java/apps/sarafrika/elimika/classes/service/impl/ClassDefinitionServiceImplTest.java
+++ b/src/test/java/apps/sarafrika/elimika/classes/service/impl/ClassDefinitionServiceImplTest.java
@@ -1,0 +1,266 @@
+package apps.sarafrika.elimika.classes.service.impl;
+
+import apps.sarafrika.elimika.availability.spi.AvailabilityService;
+import apps.sarafrika.elimika.classes.dto.ClassDefinitionDTO;
+import apps.sarafrika.elimika.classes.dto.ClassDefinitionResponseDTO;
+import apps.sarafrika.elimika.classes.dto.ClassRecurrenceDTO;
+import apps.sarafrika.elimika.classes.dto.ClassSessionTemplateDTO;
+import apps.sarafrika.elimika.classes.model.ClassDefinition;
+import apps.sarafrika.elimika.classes.model.ClassSessionTemplate;
+import apps.sarafrika.elimika.classes.repository.ClassDefinitionRepository;
+import apps.sarafrika.elimika.classes.repository.ClassSchedulingConflictRepository;
+import apps.sarafrika.elimika.classes.repository.ClassSessionTemplateRepository;
+import apps.sarafrika.elimika.classes.util.enums.ClassRecurrenceType;
+import apps.sarafrika.elimika.classes.util.enums.ConflictResolutionStrategy;
+import apps.sarafrika.elimika.course.spi.CourseInfoService;
+import apps.sarafrika.elimika.course.spi.CourseTrainingApprovalSpi;
+import apps.sarafrika.elimika.shared.enums.ClassVisibility;
+import apps.sarafrika.elimika.shared.enums.LocationType;
+import apps.sarafrika.elimika.shared.enums.SessionFormat;
+import apps.sarafrika.elimika.shared.spi.ClassScheduleService;
+import apps.sarafrika.elimika.timetabling.spi.ScheduleRequestDTO;
+import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceDTO;
+import apps.sarafrika.elimika.timetabling.spi.SchedulingStatus;
+import apps.sarafrika.elimika.timetabling.spi.TimetableService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ClassDefinitionServiceImplTest {
+
+    @Mock
+    private ClassDefinitionRepository classDefinitionRepository;
+
+    @Mock
+    private ClassSchedulingConflictRepository classSchedulingConflictRepository;
+
+    @Mock
+    private ClassSessionTemplateRepository classSessionTemplateRepository;
+
+    @Mock
+    private AvailabilityService availabilityService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    private CourseInfoService courseInfoService;
+
+    @Mock
+    private CourseTrainingApprovalSpi courseTrainingApprovalSpi;
+
+    @Mock
+    private ObjectProvider<TimetableService> timetableServiceProvider;
+
+    @Mock
+    private ObjectProvider<ClassScheduleService> classScheduleServiceProvider;
+
+    @Mock
+    private TimetableService timetableService;
+
+    private ClassDefinitionServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ClassDefinitionServiceImpl(
+                classDefinitionRepository,
+                classSchedulingConflictRepository,
+                classSessionTemplateRepository,
+                availabilityService,
+                eventPublisher,
+                courseInfoService,
+                courseTrainingApprovalSpi,
+                timetableServiceProvider,
+                classScheduleServiceProvider
+        );
+    }
+
+    @Test
+    void createClassDefinitionPersistsSessionTemplatesAndReturnsThem() {
+        UUID classUuid = UUID.randomUUID();
+        ClassDefinitionDTO request = sampleClassDefinition();
+
+        when(classDefinitionRepository.save(any(ClassDefinition.class))).thenAnswer(invocation -> {
+            ClassDefinition entity = invocation.getArgument(0);
+            entity.setUuid(classUuid);
+            return entity;
+        });
+        when(classSessionTemplateRepository.saveAll(any())).thenAnswer(invocation -> {
+            List<ClassSessionTemplate> templates = invocation.getArgument(0);
+            templates.forEach(template -> template.setUuid(UUID.randomUUID()));
+            return templates;
+        });
+        when(availabilityService.getAvailabilityForInstructor(request.defaultInstructorUuid())).thenReturn(List.of());
+        when(availabilityService.isInstructorAvailable(
+                request.defaultInstructorUuid(),
+                request.sessionTemplates().getFirst().startTime(),
+                request.sessionTemplates().getFirst().endTime()))
+                .thenReturn(true);
+        when(timetableServiceProvider.getIfAvailable()).thenReturn(timetableService);
+        when(classScheduleServiceProvider.getIfAvailable()).thenReturn(null);
+        when(timetableService.hasInstructorConflict(any(UUID.class), any(ScheduleRequestDTO.class))).thenReturn(false);
+        when(timetableService.scheduleClass(any(ScheduleRequestDTO.class))).thenReturn(sampleScheduledInstance(classUuid));
+
+        ClassDefinitionResponseDTO response = service.createClassDefinition(request);
+
+        assertThat(response.classDefinition().sessionTemplates()).hasSize(1);
+        assertThat(response.classDefinition().sessionTemplates().getFirst().uuid()).isNotNull();
+
+        verify(classSessionTemplateRepository).saveAll(argThat(templates -> {
+            List<ClassSessionTemplate> captured = StreamSupport.stream(templates.spliterator(), false).toList();
+            assertThat(captured)
+                    .hasSize(1)
+                    .first()
+                    .satisfies(template -> {
+                        assertThat(template.getClassDefinitionUuid()).isEqualTo(classUuid);
+                        assertThat(template.getTemplateOrder()).isZero();
+                        assertThat(template.getConflictResolution()).isEqualTo(ConflictResolutionStrategy.FAIL);
+                    });
+            return true;
+        }));
+        verify(timetableService).scheduleClass(any(ScheduleRequestDTO.class));
+    }
+
+    @Test
+    void getClassDefinitionReturnsPersistedSessionTemplates() {
+        UUID classUuid = UUID.randomUUID();
+        ClassDefinition entity = sampleClassDefinitionEntity();
+        entity.setUuid(classUuid);
+        ClassSessionTemplate template = sampleSessionTemplate(classUuid);
+        template.setUuid(UUID.randomUUID());
+
+        when(classDefinitionRepository.findByUuid(classUuid)).thenReturn(Optional.of(entity));
+        when(classSessionTemplateRepository.findByClassDefinitionUuidOrderByTemplateOrderAscCreatedDateAsc(classUuid))
+                .thenReturn(List.of(template));
+        when(classScheduleServiceProvider.getIfAvailable()).thenReturn(null);
+
+        ClassDefinitionResponseDTO response = service.getClassDefinition(classUuid);
+
+        assertThat(response.classDefinition().sessionTemplates()).hasSize(1);
+        ClassSessionTemplateDTO resultTemplate = response.classDefinition().sessionTemplates().getFirst();
+        assertThat(resultTemplate.uuid()).isEqualTo(template.getUuid());
+        assertThat(resultTemplate.recurrence().recurrenceType()).isEqualTo(ClassRecurrenceDTO.RecurrenceType.WEEKLY);
+    }
+
+    private ClassDefinitionDTO sampleClassDefinition() {
+        return new ClassDefinitionDTO(
+                null,
+                "Data Science Cohort",
+                "Applied analytics class",
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                null,
+                null,
+                null,
+                ClassVisibility.PUBLIC,
+                SessionFormat.GROUP,
+                LocalDateTime.of(2026, 6, 12, 9, 0),
+                LocalDateTime.of(2026, 6, 12, 11, 0),
+                null,
+                null,
+                null,
+                null,
+                30,
+                "#1F6FEB",
+                LocationType.ONLINE,
+                null,
+                null,
+                null,
+                "https://meet.google.com/abc-defg-hij",
+                25,
+                true,
+                true,
+                List.of(new ClassSessionTemplateDTO(
+                        LocalDateTime.of(2026, 6, 12, 9, 0),
+                        LocalDateTime.of(2026, 6, 12, 11, 0),
+                        new ClassRecurrenceDTO(
+                                ClassRecurrenceDTO.RecurrenceType.WEEKLY,
+                                1,
+                                "FRIDAY",
+                                null,
+                                null,
+                                1
+                        ),
+                        ConflictResolutionStrategy.FAIL
+                )),
+                null,
+                null,
+                null,
+                null
+        );
+    }
+
+    private ClassDefinition sampleClassDefinitionEntity() {
+        ClassDefinition entity = new ClassDefinition();
+        entity.setTitle("Data Science Cohort");
+        entity.setDescription("Applied analytics class");
+        entity.setDefaultInstructorUuid(UUID.randomUUID());
+        entity.setOrganisationUuid(UUID.randomUUID());
+        entity.setClassVisibility(ClassVisibility.PUBLIC);
+        entity.setSessionFormat(SessionFormat.GROUP);
+        entity.setDefaultStartTime(LocalDateTime.of(2026, 6, 12, 9, 0));
+        entity.setDefaultEndTime(LocalDateTime.of(2026, 6, 12, 11, 0));
+        entity.setClassReminderMinutes(30);
+        entity.setClassColor("#1F6FEB");
+        entity.setLocationType(LocationType.ONLINE);
+        entity.setMeetingLink("https://meet.google.com/abc-defg-hij");
+        entity.setMaxParticipants(25);
+        entity.setAllowWaitlist(true);
+        entity.setIsActive(true);
+        return entity;
+    }
+
+    private ClassSessionTemplate sampleSessionTemplate(UUID classUuid) {
+        ClassSessionTemplate template = new ClassSessionTemplate();
+        template.setClassDefinitionUuid(classUuid);
+        template.setTemplateOrder(0);
+        template.setStartTime(LocalDateTime.of(2026, 6, 12, 9, 0));
+        template.setEndTime(LocalDateTime.of(2026, 6, 12, 11, 0));
+        template.setRecurrenceType(ClassRecurrenceType.WEEKLY);
+        template.setIntervalValue(1);
+        template.setDaysOfWeek("FRIDAY");
+        template.setOccurrenceCount(1);
+        template.setConflictResolution(ConflictResolutionStrategy.FAIL);
+        return template;
+    }
+
+    private ScheduledInstanceDTO sampleScheduledInstance(UUID classUuid) {
+        return new ScheduledInstanceDTO(
+                UUID.randomUUID(),
+                classUuid,
+                UUID.randomUUID(),
+                LocalDateTime.of(2026, 6, 12, 9, 0),
+                LocalDateTime.of(2026, 6, 12, 11, 0),
+                "UTC",
+                "Data Science Cohort",
+                "ONLINE",
+                null,
+                null,
+                null,
+                25,
+                SchedulingStatus.SCHEDULED,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/src/test/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImplTest.java
+++ b/src/test/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImplTest.java
@@ -18,6 +18,7 @@ import apps.sarafrika.elimika.timetabling.repository.ScheduledInstanceRepository
 import apps.sarafrika.elimika.timetabling.spi.EnrollmentDTO;
 import apps.sarafrika.elimika.timetabling.spi.EnrollmentStatus;
 import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceDTO;
+import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceRescheduleRequestDTO;
 import apps.sarafrika.elimika.timetabling.spi.SchedulingStatus;
 import apps.sarafrika.elimika.timetabling.spi.StudentCourseEnrollmentSummaryDTO;
 import apps.sarafrika.elimika.timetabling.spi.StudentClassEnrollmentSummaryDTO;
@@ -159,6 +160,82 @@ class TimetableServiceImplTest {
         assertThatThrownBy(() -> timetableService.startScheduledInstance(instanceUuid))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("cannot be started");
+
+        verify(scheduledInstanceRepository, never()).save(any(ScheduledInstance.class));
+    }
+
+    @Test
+    void rescheduleScheduledInstanceUpdatesScheduledTimeAndIgnoresSelfOverlap() {
+        UUID instanceUuid = UUID.randomUUID();
+        UUID instructorUuid = UUID.randomUUID();
+        ScheduledInstance instance = buildScheduledInstance(instructorUuid, SchedulingStatus.SCHEDULED);
+        instance.setUuid(instanceUuid);
+        LocalDateTime newStart = LocalDateTime.of(2026, 6, 12, 9, 0);
+        LocalDateTime newEnd = LocalDateTime.of(2026, 6, 12, 11, 0);
+
+        when(scheduledInstanceRepository.findByUuid(instanceUuid)).thenReturn(Optional.of(instance));
+        when(availabilityService.isInstructorAvailable(instructorUuid, newStart, newEnd)).thenReturn(true);
+        when(scheduledInstanceRepository.findOverlappingInstancesForInstructor(instructorUuid, newStart, newEnd))
+                .thenReturn(List.of(instance));
+        when(scheduledInstanceRepository.save(any(ScheduledInstance.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        ScheduledInstanceDTO result = timetableService.rescheduleScheduledInstance(
+                instanceUuid,
+                new ScheduledInstanceRescheduleRequestDTO(newStart, newEnd, "Africa/Nairobi")
+        );
+
+        assertThat(result.uuid()).isEqualTo(instanceUuid);
+        assertThat(result.startTime()).isEqualTo(newStart);
+        assertThat(result.endTime()).isEqualTo(newEnd);
+        assertThat(result.timezone()).isEqualTo("Africa/Nairobi");
+        assertThat(instance.getStartTime()).isEqualTo(newStart);
+        assertThat(instance.getEndTime()).isEqualTo(newEnd);
+    }
+
+    @Test
+    void rescheduleScheduledInstanceRejectsCompletedInstance() {
+        UUID instanceUuid = UUID.randomUUID();
+        ScheduledInstance instance = buildScheduledInstance(UUID.randomUUID(), SchedulingStatus.COMPLETED);
+        instance.setUuid(instanceUuid);
+
+        when(scheduledInstanceRepository.findByUuid(instanceUuid)).thenReturn(Optional.of(instance));
+
+        assertThatThrownBy(() -> timetableService.rescheduleScheduledInstance(
+                instanceUuid,
+                new ScheduledInstanceRescheduleRequestDTO(
+                        LocalDateTime.of(2026, 6, 12, 9, 0),
+                        LocalDateTime.of(2026, 6, 12, 11, 0),
+                        null
+                )))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Only scheduled instances can be rescheduled");
+
+        verify(scheduledInstanceRepository, never()).save(any(ScheduledInstance.class));
+        verifyNoInteractions(availabilityService);
+    }
+
+    @Test
+    void rescheduleScheduledInstanceRejectsOtherInstructorOverlap() {
+        UUID instanceUuid = UUID.randomUUID();
+        UUID instructorUuid = UUID.randomUUID();
+        ScheduledInstance instance = buildScheduledInstance(instructorUuid, SchedulingStatus.SCHEDULED);
+        instance.setUuid(instanceUuid);
+        ScheduledInstance overlapping = buildScheduledInstance(instructorUuid, SchedulingStatus.SCHEDULED);
+        LocalDateTime newStart = LocalDateTime.of(2026, 6, 12, 9, 0);
+        LocalDateTime newEnd = LocalDateTime.of(2026, 6, 12, 11, 0);
+
+        when(scheduledInstanceRepository.findByUuid(instanceUuid)).thenReturn(Optional.of(instance));
+        when(availabilityService.isInstructorAvailable(instructorUuid, newStart, newEnd)).thenReturn(true);
+        when(scheduledInstanceRepository.findOverlappingInstancesForInstructor(instructorUuid, newStart, newEnd))
+                .thenReturn(List.of(instance, overlapping));
+
+        assertThatThrownBy(() -> timetableService.rescheduleScheduledInstance(
+                instanceUuid,
+                new ScheduledInstanceRescheduleRequestDTO(newStart, newEnd, null)
+        ))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("overlap");
 
         verify(scheduledInstanceRepository, never()).save(any(ScheduledInstance.class));
     }


### PR DESCRIPTION
## Summary
- Persist class session templates so class reads can return the schedule template originally used at creation time.
- Split create and update request contracts so class metadata updates no longer require session_templates.
- Add explicit APIs for appending class session templates and rescheduling individual scheduled instances.

## Changes
- Added class_session_templates Flyway migration, entity, repository, converters, and template mapping.
- Added POST /api/v1/classes/{uuid}/session-templates for adding more sessions to a class.
- Added PATCH /api/v1/timetable/schedule/{instanceUuid}/time for rescheduling a scheduled instance while keeping enrollments attached.
- Kept GET /api/v1/classes/{uuid}/schedule paginated through the existing PagedDTO response.

## Tests
- /usr/bin/env JAVA_HOME=/home/willy/.jdks/temurin-21.0.11 ./gradlew test

## Configuration / Secret Impacts
- Adds a database migration only.
- No new environment variables or secrets required.