### PR TITLE
feat: add class thumbnail and promotional video uploads

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/classes/controller/ClassDefinitionController.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/controller/ClassDefinitionController.java
@@ -10,6 +10,9 @@ import apps.sarafrika.elimika.classes.exception.SchedulingConflictException;
 import apps.sarafrika.elimika.classes.service.ClassDefinitionServiceInterface;
 import apps.sarafrika.elimika.shared.dto.ApiResponse;
 import apps.sarafrika.elimika.shared.dto.PagedDTO;
+import apps.sarafrika.elimika.shared.storage.config.StorageProperties;
+import apps.sarafrika.elimika.shared.storage.service.StorageService;
+import apps.sarafrika.elimika.shared.storage.util.StoragePathUtils;
 import apps.sarafrika.elimika.timetabling.spi.EnrollmentDTO;
 import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceDTO;
 import apps.sarafrika.elimika.timetabling.spi.TimetableService;
@@ -19,10 +22,14 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.List;
@@ -38,6 +45,8 @@ public class ClassDefinitionController {
 
     private final ClassDefinitionServiceInterface classDefinitionService;
     private final TimetableService timetableService;
+    private final StorageService storageService;
+    private final StorageProperties storageProperties;
 
     // ================================
     // CORE CLASS DEFINITION MANAGEMENT
@@ -124,6 +133,61 @@ public class ClassDefinitionController {
         
         ClassDefinitionResponseDTO result = classDefinitionService.updateClassDefinition(uuid, request.toClassDefinitionDTO());
         return ResponseEntity.ok(ApiResponse.success(result, "Class definition updated successfully"));
+    }
+
+    @Operation(summary = "Upload class thumbnail")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Class thumbnail uploaded successfully")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Class definition not found")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid thumbnail file")
+    @PostMapping(value = "/{uuid}/thumbnail", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<ClassDefinitionResponseDTO>> uploadClassThumbnail(
+            @Parameter(description = "UUID of the class definition", required = true)
+            @PathVariable UUID uuid,
+            @Parameter(description = "Thumbnail image file. Supported formats: JPG, PNG, GIF, WebP. Maximum size: 5MB.", required = true)
+            @RequestParam("thumbnail") MultipartFile thumbnail) {
+        log.debug("REST request to upload thumbnail for class definition: {}", uuid);
+
+        ClassDefinitionResponseDTO result = classDefinitionService.uploadThumbnail(uuid, thumbnail);
+        return ResponseEntity.ok(ApiResponse.success(result, "Class thumbnail uploaded successfully"));
+    }
+
+    @Operation(summary = "Upload class promotional video")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Class promotional video uploaded successfully")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Class definition not found")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Invalid promotional video file")
+    @PostMapping(value = "/{uuid}/promotional-video", consumes = MediaType.MULTIPART_FORM_DATA_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ApiResponse<ClassDefinitionResponseDTO>> uploadClassPromotionalVideo(
+            @Parameter(description = "UUID of the class definition", required = true)
+            @PathVariable UUID uuid,
+            @Parameter(description = "Promotional video file. Supported formats: MP4, WebM, MOV, AVI. Maximum size: 100MB.", required = true)
+            @RequestParam("promotional_video") MultipartFile promotionalVideo) {
+        log.debug("REST request to upload promotional video for class definition: {}", uuid);
+
+        ClassDefinitionResponseDTO result = classDefinitionService.uploadPromotionalVideo(uuid, promotionalVideo);
+        return ResponseEntity.ok(ApiResponse.success(result, "Class promotional video uploaded successfully"));
+    }
+
+    @Operation(summary = "Get uploaded class media")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Class media retrieved successfully")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Class media not found")
+    @GetMapping("/media/{*filePath}")
+    public ResponseEntity<Resource> getClassMedia(
+            @Parameter(description = "Stored relative path of the class media file.", required = true)
+            @PathVariable String filePath) {
+        try {
+            String fullPath = resolveClassMediaPath(filePath);
+            Resource resource = storageService.load(fullPath);
+            String contentType = storageService.getContentType(fullPath);
+            String fileName = fullPath.substring(fullPath.lastIndexOf('/') + 1);
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(contentType))
+                    .header(HttpHeaders.CACHE_CONTROL, "max-age=3600, must-revalidate")
+                    .header(HttpHeaders.CONTENT_DISPOSITION, "inline; filename=\"" + fileName + "\"")
+                    .body(resource);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
     }
 
     @Operation(summary = "Add a session template to an existing class definition")
@@ -275,6 +339,17 @@ public class ClassDefinitionController {
         String baseUrl = ServletUriComponentsBuilder.fromCurrentRequestUri().build().toString();
         return ResponseEntity.ok(ApiResponse.success(PagedDTO.from(conflicts, baseUrl),
                 "Class scheduling conflicts retrieved successfully"));
+    }
+
+    private String resolveClassMediaPath(String filePath) {
+        String normalizedFilePath = StoragePathUtils.normalizeRelativePath(filePath);
+        if (normalizedFilePath == null || normalizedFilePath.contains("/")) {
+            return normalizedFilePath;
+        }
+        if (storageService.isVideo(normalizedFilePath)) {
+            return storageProperties.getFolders().getClassPromotionalVideos() + "/" + normalizedFilePath;
+        }
+        return storageProperties.getFolders().getClassThumbnails() + "/" + normalizedFilePath;
     }
 
 }

--- a/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionCreateRequestDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionCreateRequestDTO.java
@@ -55,6 +55,16 @@ public record ClassDefinitionCreateRequestDTO(
         @JsonProperty("description")
         String description,
 
+        @Schema(description = "**[OPTIONAL]** URL to class thumbnail image.", maxLength = 500)
+        @Size(max = 500, message = "Thumbnail URL must not exceed 500 characters")
+        @JsonProperty("thumbnail_url")
+        String thumbnailUrl,
+
+        @Schema(description = "**[OPTIONAL]** URL to class promotional video.", maxLength = 500)
+        @Size(max = 500, message = "Promotional video URL must not exceed 500 characters")
+        @JsonProperty("promotional_video_url")
+        String promotionalVideoUrl,
+
         @Schema(description = "**[REQUIRED]** Default instructor UUID for the class.")
         @NotNull(message = "Default instructor UUID is required")
         @JsonProperty("default_instructor_uuid")
@@ -178,6 +188,8 @@ public record ClassDefinitionCreateRequestDTO(
                 null,
                 title,
                 description,
+                thumbnailUrl,
+                promotionalVideoUrl,
                 defaultInstructorUuid,
                 organisationUuid,
                 effectiveCourseUuid,

--- a/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionDTO.java
@@ -40,6 +40,8 @@ import java.util.UUID;
             "uuid": "cd123456-7890-abcd-ef01-234567890abc",
             "title": "Introduction to Java Programming",
             "description": "Comprehensive introduction to Java programming covering basics, OOP concepts, and practical application development.",
+            "thumbnail_url": "/api/v1/classes/media/class_thumbnails/cd123456-7890-abcd-ef01-234567890abc/thumbnail.jpg",
+            "promotional_video_url": "/api/v1/classes/media/class_promotional_videos/cd123456-7890-abcd-ef01-234567890abc/promo.mp4",
             "default_instructor_uuid": "inst1234-5678-90ab-cdef-123456789abc",
             "organisation_uuid": "org12345-6789-abcd-ef01-234567890abc",
             "course_uuid": "course123-4567-89ab-cdef-123456789abc",
@@ -137,6 +139,28 @@ public record ClassDefinitionDTO(
         @Size(max = 2000, message = "Description must not exceed 2000 characters")
         @JsonProperty("description")
         String description,
+
+        @Schema(
+                description = "**[OPTIONAL]** URL to class thumbnail image for class listings and previews.",
+                example = "/api/v1/classes/media/class_thumbnails/cd123456-7890-abcd-ef01-234567890abc/thumbnail.jpg",
+                maxLength = 500,
+                nullable = true,
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        @Size(max = 500, message = "Thumbnail URL must not exceed 500 characters")
+        @JsonProperty("thumbnail_url")
+        String thumbnailUrl,
+
+        @Schema(
+                description = "**[OPTIONAL]** URL to class promotional video for marketing and preview purposes.",
+                example = "/api/v1/classes/media/class_promotional_videos/cd123456-7890-abcd-ef01-234567890abc/promo.mp4",
+                maxLength = 500,
+                nullable = true,
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        @Size(max = 500, message = "Promotional video URL must not exceed 500 characters")
+        @JsonProperty("promotional_video_url")
+        String promotionalVideoUrl,
 
         @Schema(
                 description = "**[REQUIRED]** Reference to the default instructor UUID for this class definition.",
@@ -457,6 +481,8 @@ public record ClassDefinitionDTO(
             UUID uuid,
             String title,
             String description,
+            String thumbnailUrl,
+            String promotionalVideoUrl,
             UUID defaultInstructorUuid,
             UUID organisationUuid,
             UUID courseUuid,
@@ -490,6 +516,8 @@ public record ClassDefinitionDTO(
                 uuid,
                 title,
                 description,
+                thumbnailUrl,
+                promotionalVideoUrl,
                 defaultInstructorUuid,
                 organisationUuid,
                 courseUuid,
@@ -524,6 +552,76 @@ public record ClassDefinitionDTO(
         );
     }
 
+    public ClassDefinitionDTO(
+            UUID uuid,
+            String title,
+            String description,
+            UUID defaultInstructorUuid,
+            UUID organisationUuid,
+            UUID courseUuid,
+            UUID programUuid,
+            BigDecimal trainingFee,
+            ClassVisibility classVisibility,
+            SessionFormat sessionFormat,
+            LocalDateTime defaultStartTime,
+            LocalDateTime defaultEndTime,
+            LocalDate academicPeriodStartDate,
+            LocalDate academicPeriodEndDate,
+            LocalDate registrationPeriodStartDate,
+            LocalDate registrationPeriodEndDate,
+            Integer classReminderMinutes,
+            String classColor,
+            LocationType locationType,
+            String locationName,
+            BigDecimal locationLatitude,
+            BigDecimal locationLongitude,
+            String meetingLink,
+            Integer maxParticipants,
+            Boolean allowWaitlist,
+            Boolean isActive,
+            List<ClassSessionTemplateDTO> sessionTemplates,
+            LocalDateTime createdDate,
+            LocalDateTime updatedDate,
+            String createdBy,
+            String updatedBy
+    ) {
+        this(
+                uuid,
+                title,
+                description,
+                null,
+                null,
+                defaultInstructorUuid,
+                organisationUuid,
+                courseUuid,
+                programUuid,
+                trainingFee,
+                classVisibility,
+                sessionFormat,
+                defaultStartTime,
+                defaultEndTime,
+                academicPeriodStartDate,
+                academicPeriodEndDate,
+                registrationPeriodStartDate,
+                registrationPeriodEndDate,
+                classReminderMinutes,
+                classColor,
+                locationType,
+                locationName,
+                locationLatitude,
+                locationLongitude,
+                meetingLink,
+                maxParticipants,
+                allowWaitlist,
+                isActive,
+                sessionTemplates,
+                createdDate,
+                updatedDate,
+                createdBy,
+                updatedBy
+        );
+    }
+
     public ClassDefinitionDTO withScheduleProgress(long scheduledSessions,
                                                    long completedSessions,
                                                    BigDecimal progressPercentage) {
@@ -531,6 +629,8 @@ public record ClassDefinitionDTO(
                 uuid,
                 title,
                 description,
+                thumbnailUrl,
+                promotionalVideoUrl,
                 defaultInstructorUuid,
                 organisationUuid,
                 courseUuid,
@@ -570,6 +670,8 @@ public record ClassDefinitionDTO(
                 uuid,
                 title,
                 description,
+                thumbnailUrl,
+                promotionalVideoUrl,
                 defaultInstructorUuid,
                 organisationUuid,
                 courseUuid,

--- a/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionUpdateRequestDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/dto/ClassDefinitionUpdateRequestDTO.java
@@ -53,6 +53,16 @@ public record ClassDefinitionUpdateRequestDTO(
         @JsonProperty("description")
         String description,
 
+        @Schema(description = "**[OPTIONAL]** URL to class thumbnail image.", maxLength = 500)
+        @Size(max = 500, message = "Thumbnail URL must not exceed 500 characters")
+        @JsonProperty("thumbnail_url")
+        String thumbnailUrl,
+
+        @Schema(description = "**[OPTIONAL]** URL to class promotional video.", maxLength = 500)
+        @Size(max = 500, message = "Promotional video URL must not exceed 500 characters")
+        @JsonProperty("promotional_video_url")
+        String promotionalVideoUrl,
+
         @Schema(description = "**[REQUIRED]** Default instructor UUID for the class.")
         @NotNull(message = "Default instructor UUID is required")
         @JsonProperty("default_instructor_uuid")
@@ -165,6 +175,8 @@ public record ClassDefinitionUpdateRequestDTO(
                 null,
                 title,
                 description,
+                thumbnailUrl,
+                promotionalVideoUrl,
                 defaultInstructorUuid,
                 organisationUuid,
                 courseUuid,

--- a/src/main/java/apps/sarafrika/elimika/classes/factory/ClassDefinitionFactory.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/factory/ClassDefinitionFactory.java
@@ -16,6 +16,8 @@ public class ClassDefinitionFactory {
                 entity.getUuid(),
                 entity.getTitle(),
                 entity.getDescription(),
+                entity.getThumbnailUrl(),
+                entity.getPromotionalVideoUrl(),
                 entity.getDefaultInstructorUuid(),
                 entity.getOrganisationUuid(),
                 entity.getCourseUuid(),
@@ -55,6 +57,8 @@ public class ClassDefinitionFactory {
         entity.setUuid(dto.uuid());
         entity.setTitle(dto.title());
         entity.setDescription(dto.description());
+        entity.setThumbnailUrl(dto.thumbnailUrl());
+        entity.setPromotionalVideoUrl(dto.promotionalVideoUrl());
         entity.setDefaultInstructorUuid(dto.defaultInstructorUuid());
         entity.setOrganisationUuid(dto.organisationUuid());
         entity.setCourseUuid(dto.courseUuid());
@@ -91,6 +95,12 @@ public class ClassDefinitionFactory {
         }
         if (dto.description() != null) {
             entity.setDescription(dto.description());
+        }
+        if (dto.thumbnailUrl() != null) {
+            entity.setThumbnailUrl(dto.thumbnailUrl());
+        }
+        if (dto.promotionalVideoUrl() != null) {
+            entity.setPromotionalVideoUrl(dto.promotionalVideoUrl());
         }
         if (dto.defaultInstructorUuid() != null) {
             entity.setDefaultInstructorUuid(dto.defaultInstructorUuid());

--- a/src/main/java/apps/sarafrika/elimika/classes/internal/ClassMediaValidationService.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/internal/ClassMediaValidationService.java
@@ -1,0 +1,60 @@
+package apps.sarafrika.elimika.classes.internal;
+
+import apps.sarafrika.elimika.shared.storage.service.StorageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ClassMediaValidationService {
+
+    private static final long MAX_THUMBNAIL_SIZE = 5 * 1024 * 1024;
+    private static final long MAX_PROMOTIONAL_VIDEO_SIZE = 100 * 1024 * 1024;
+
+    private final StorageService storageService;
+
+    public void validateThumbnail(MultipartFile file) {
+        validateFileNotEmpty(file);
+        validateFileSize(file, MAX_THUMBNAIL_SIZE, "Thumbnail");
+        validateImageFile(file, "Thumbnail");
+    }
+
+    public void validatePromotionalVideo(MultipartFile file) {
+        validateFileNotEmpty(file);
+        validateFileSize(file, MAX_PROMOTIONAL_VIDEO_SIZE, "Promotional video");
+        validateVideoFile(file, "Promotional video");
+    }
+
+    private void validateFileNotEmpty(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new IllegalArgumentException("File cannot be empty");
+        }
+    }
+
+    private void validateFileSize(MultipartFile file, long maxSize, String fileType) {
+        if (file.getSize() > maxSize) {
+            throw new IllegalArgumentException(
+                    String.format("%s file size cannot exceed %d MB", fileType, maxSize / (1024 * 1024))
+            );
+        }
+    }
+
+    private void validateImageFile(MultipartFile file, String fileType) {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !storageService.isImage(originalFilename)) {
+            throw new IllegalArgumentException(
+                    String.format("%s must be an image file (JPG, PNG, GIF, WebP)", fileType)
+            );
+        }
+    }
+
+    private void validateVideoFile(MultipartFile file, String fileType) {
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || !storageService.isVideo(originalFilename)) {
+            throw new IllegalArgumentException(
+                    String.format("%s must be a video file (MP4, WebM, MOV, AVI)", fileType)
+            );
+        }
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/classes/model/ClassDefinition.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/model/ClassDefinition.java
@@ -31,6 +31,12 @@ public class ClassDefinition extends BaseEntity {
     @Column(name = "description")
     private String description;
 
+    @Column(name = "thumbnail_url")
+    private String thumbnailUrl;
+
+    @Column(name = "promotional_video_url")
+    private String promotionalVideoUrl;
+
     @Column(name = "default_instructor_uuid")
     private UUID defaultInstructorUuid;
 

--- a/src/main/java/apps/sarafrika/elimika/classes/service/ClassDefinitionServiceInterface.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/service/ClassDefinitionServiceInterface.java
@@ -8,6 +8,7 @@ import apps.sarafrika.elimika.classes.dto.ClassSessionTemplateScheduleResponseDT
 import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.UUID;
@@ -27,6 +28,10 @@ public interface ClassDefinitionServiceInterface {
     ClassDefinitionResponseDTO createClassDefinition(ClassDefinitionDTO classDefinition);
 
     ClassDefinitionResponseDTO updateClassDefinition(UUID definitionUuid, ClassDefinitionDTO classDefinition);
+
+    ClassDefinitionResponseDTO uploadThumbnail(UUID definitionUuid, MultipartFile thumbnail);
+
+    ClassDefinitionResponseDTO uploadPromotionalVideo(UUID definitionUuid, MultipartFile promotionalVideo);
 
     ClassSessionTemplateScheduleResponseDTO addSessionTemplate(UUID definitionUuid, ClassSessionTemplateDTO sessionTemplate);
 

--- a/src/main/java/apps/sarafrika/elimika/classes/service/impl/ClassDefinitionServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/service/impl/ClassDefinitionServiceImpl.java
@@ -4,6 +4,7 @@ import apps.sarafrika.elimika.availability.spi.AvailabilityService;
 import apps.sarafrika.elimika.classes.dto.*;
 import apps.sarafrika.elimika.classes.factory.ClassDefinitionFactory;
 import apps.sarafrika.elimika.classes.factory.ClassSessionTemplateFactory;
+import apps.sarafrika.elimika.classes.internal.ClassMediaValidationService;
 import apps.sarafrika.elimika.classes.model.ClassSchedulingConflict;
 import apps.sarafrika.elimika.classes.model.ClassDefinition;
 import apps.sarafrika.elimika.classes.model.ClassSessionTemplate;
@@ -23,6 +24,8 @@ import apps.sarafrika.elimika.shared.event.classes.ClassDefinitionDeactivatedEve
 import apps.sarafrika.elimika.shared.event.classes.ClassDefinitionUpdatedEventDTO;
 import apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException;
 import apps.sarafrika.elimika.shared.spi.ClassScheduleService;
+import apps.sarafrika.elimika.shared.storage.config.StorageProperties;
+import apps.sarafrika.elimika.shared.storage.service.StorageService;
 import apps.sarafrika.elimika.timetabling.spi.ScheduleRequestDTO;
 import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceDTO;
 import apps.sarafrika.elimika.timetabling.spi.TimetableService;
@@ -34,7 +37,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.util.UriUtils;
 
+import java.nio.charset.StandardCharsets;
 import java.math.BigDecimal;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -58,9 +64,13 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
     private final CourseTrainingApprovalSpi courseTrainingApprovalSpi;
     private final ObjectProvider<TimetableService> timetableServiceProvider;
     private final ObjectProvider<ClassScheduleService> classScheduleServiceProvider;
+    private final StorageService storageService;
+    private final StorageProperties storageProperties;
+    private final ClassMediaValidationService classMediaValidationService;
 
     private static final String CLASS_DEFINITION_NOT_FOUND_TEMPLATE = "Class definition with UUID %s not found";
     private static final String TRAINING_PROGRAM_NOT_FOUND_TEMPLATE = "Training program with UUID %s not found";
+    private static final String CLASS_MEDIA_URL_PREFIX = "/api/v1/classes/media/";
     private static final int MAX_SCHEDULING_ITERATIONS = 2000;
     private static final int MAX_ROLLOVER_ITERATIONS = 20;
 
@@ -585,6 +595,15 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
                         String.format(CLASS_DEFINITION_NOT_FOUND_TEMPLATE, classDefinitionUuid)));
     }
 
+    private ClassDefinition requireClassDefinition(UUID classDefinitionUuid) {
+        if (classDefinitionUuid == null) {
+            throw new IllegalArgumentException("Class definition UUID cannot be null");
+        }
+        return classDefinitionRepository.findByUuid(classDefinitionUuid)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        String.format(CLASS_DEFINITION_NOT_FOUND_TEMPLATE, classDefinitionUuid)));
+    }
+
     private ClassDefinitionDTO toDTOWithSessionTemplates(ClassDefinition entity) {
         ClassDefinitionDTO dto = ClassDefinitionFactory.toDTO(entity);
         if (dto == null || dto.uuid() == null) {
@@ -615,6 +634,20 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
         int templateOrder = Math.toIntExact(classSessionTemplateRepository.countByClassDefinitionUuid(classDefinitionUuid));
         ClassSessionTemplate entity = ClassSessionTemplateFactory.toEntity(classDefinitionUuid, sessionTemplate, templateOrder);
         return ClassSessionTemplateFactory.toDTO(classSessionTemplateRepository.save(entity));
+    }
+
+    private String storeClassMedia(MultipartFile file, String folder) {
+        String storedPath = storageService.store(file, folder);
+        String encodedPath = UriUtils.encodePath(storedPath, StandardCharsets.UTF_8);
+        return CLASS_MEDIA_URL_PREFIX + encodedPath;
+    }
+
+    private void publishClassDefinitionUpdated(ClassDefinitionDTO result) {
+        ClassDefinitionUpdatedEventDTO event = new ClassDefinitionUpdatedEventDTO(
+                result.uuid(),
+                result.title()
+        );
+        eventPublisher.publishEvent(event);
     }
 
     private void persistSchedulingConflicts(UUID classDefinitionUuid, List<ClassSchedulingConflictDTO> conflicts) {
@@ -656,15 +689,50 @@ public class ClassDefinitionServiceImpl implements ClassDefinitionServiceInterfa
         ClassDefinition savedEntity = classDefinitionRepository.save(existingEntity);
         ClassDefinitionDTO result = toDTOWithSessionTemplates(savedEntity);
         
-        // Publish domain event
-        ClassDefinitionUpdatedEventDTO event = new ClassDefinitionUpdatedEventDTO(
-                result.uuid(),
-                result.title()
-        );
-        eventPublisher.publishEvent(event);
+        publishClassDefinitionUpdated(result);
         
         log.info("Updated class definition with UUID: {} and published ClassDefinitionUpdatedEvent", definitionUuid);
         return buildResponse(result);
+    }
+
+    @Override
+    public ClassDefinitionResponseDTO uploadThumbnail(UUID definitionUuid, MultipartFile thumbnail) {
+        log.debug("Uploading thumbnail for class definition: {}", definitionUuid);
+
+        classMediaValidationService.validateThumbnail(thumbnail);
+        ClassDefinition entity = requireClassDefinition(definitionUuid);
+
+        try {
+            String folder = storageProperties.getFolders().getClassThumbnails() + "/" + definitionUuid;
+            entity.setThumbnailUrl(storeClassMedia(thumbnail, folder));
+            ClassDefinition savedEntity = classDefinitionRepository.save(entity);
+            ClassDefinitionDTO result = toDTOWithSessionTemplates(savedEntity);
+            publishClassDefinitionUpdated(result);
+            return buildResponse(result);
+        } catch (Exception ex) {
+            log.error("Failed to upload class thumbnail for UUID: {}", definitionUuid, ex);
+            throw new RuntimeException("Failed to upload class thumbnail: " + ex.getMessage(), ex);
+        }
+    }
+
+    @Override
+    public ClassDefinitionResponseDTO uploadPromotionalVideo(UUID definitionUuid, MultipartFile promotionalVideo) {
+        log.debug("Uploading promotional video for class definition: {}", definitionUuid);
+
+        classMediaValidationService.validatePromotionalVideo(promotionalVideo);
+        ClassDefinition entity = requireClassDefinition(definitionUuid);
+
+        try {
+            String folder = storageProperties.getFolders().getClassPromotionalVideos() + "/" + definitionUuid;
+            entity.setPromotionalVideoUrl(storeClassMedia(promotionalVideo, folder));
+            ClassDefinition savedEntity = classDefinitionRepository.save(entity);
+            ClassDefinitionDTO result = toDTOWithSessionTemplates(savedEntity);
+            publishClassDefinitionUpdated(result);
+            return buildResponse(result);
+        } catch (Exception ex) {
+            log.error("Failed to upload class promotional video for UUID: {}", definitionUuid, ex);
+            throw new RuntimeException("Failed to upload class promotional video: " + ex.getMessage(), ex);
+        }
     }
 
     @Override

--- a/src/main/java/apps/sarafrika/elimika/shared/storage/config/StorageProperties.java
+++ b/src/main/java/apps/sarafrika/elimika/shared/storage/config/StorageProperties.java
@@ -46,6 +46,16 @@ public class StorageProperties {
         private String courseMaterials = "course_materials";
 
         /**
+         * Folder for class thumbnails
+         */
+        private String classThumbnails = "class_thumbnails";
+
+        /**
+         * Folder for class promotional videos
+         */
+        private String classPromotionalVideos = "class_promotional_videos";
+
+        /**
          * Folder for organization logos
          */
         private String organizationLogos = "organization_logos";

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -81,6 +81,8 @@ storage:
     profile-images: ${PROFILE_IMAGES_FOLDER:profile_images}
     course-thumbnails: ${COURSE_THUMBNAILS_FOLDER:course_thumbnails}
     course-materials: ${COURSE_MATERIALS_FOLDER:course_materials}
+    class-thumbnails: ${CLASS_THUMBNAILS_FOLDER:class_thumbnails}
+    class-promotional-videos: ${CLASS_PROMOTIONAL_VIDEOS_FOLDER:class_promotional_videos}
     organization-logos: ${ORGANIZATION_LOGOS_FOLDER:organization_logos}
     certificates: ${CERTIFICATES_FOLDER:certificates}
     assignments: ${ASSIGNMENTS_FOLDER:assignments}

--- a/src/main/resources/db/migration/V202606111802__add_class_media_urls.sql
+++ b/src/main/resources/db/migration/V202606111802__add_class_media_urls.sql
@@ -1,0 +1,6 @@
+ALTER TABLE class_definitions
+    ADD COLUMN thumbnail_url VARCHAR(500),
+    ADD COLUMN promotional_video_url VARCHAR(500);
+
+COMMENT ON COLUMN class_definitions.thumbnail_url IS 'Optional thumbnail image URL for class listings and previews';
+COMMENT ON COLUMN class_definitions.promotional_video_url IS 'Optional promotional video URL for class marketing and previews';

--- a/src/test/java/apps/sarafrika/elimika/classes/controller/ClassDefinitionControllerTest.java
+++ b/src/test/java/apps/sarafrika/elimika/classes/controller/ClassDefinitionControllerTest.java
@@ -12,6 +12,8 @@ import apps.sarafrika.elimika.shared.config.GlobalExceptionHandler;
 import apps.sarafrika.elimika.shared.enums.ClassVisibility;
 import apps.sarafrika.elimika.shared.enums.LocationType;
 import apps.sarafrika.elimika.shared.enums.SessionFormat;
+import apps.sarafrika.elimika.shared.storage.config.StorageProperties;
+import apps.sarafrika.elimika.shared.storage.service.StorageService;
 import apps.sarafrika.elimika.shared.tracking.service.RequestAuditService;
 import apps.sarafrika.elimika.tenancy.spi.UserManagementService;
 import apps.sarafrika.elimika.timetabling.spi.TimetableService;
@@ -21,12 +23,14 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
@@ -44,8 +48,11 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -73,9 +80,12 @@ class ClassDefinitionControllerTest {
     @Autowired
     private RequestAuditService requestAuditService;
 
+    @Autowired
+    private StorageService storageService;
+
     @BeforeEach
     void setUp() {
-        reset(classDefinitionService, timetableService, userManagementService, requestAuditService);
+        reset(classDefinitionService, timetableService, userManagementService, requestAuditService, storageService);
     }
 
     @Test
@@ -137,6 +147,128 @@ class ClassDefinitionControllerTest {
         ArgumentCaptor<ClassDefinitionDTO> captor = ArgumentCaptor.forClass(ClassDefinitionDTO.class);
         verify(classDefinitionService).updateClassDefinition(eq(classUuid), captor.capture());
         assertNull(captor.getValue().sessionTemplates());
+    }
+
+    @Test
+    void uploadClassThumbnailReturnsUpdatedClassDefinition() throws Exception {
+        UUID classUuid = UUID.randomUUID();
+        ClassDefinitionDTO responseDto = sampleRequest(UUID.randomUUID(), null, 30, "#1F6FEB");
+        responseDto = new ClassDefinitionDTO(
+                responseDto.uuid(),
+                responseDto.title(),
+                responseDto.description(),
+                "/api/v1/classes/media/class_thumbnails/" + classUuid + "/image.png",
+                responseDto.promotionalVideoUrl(),
+                responseDto.defaultInstructorUuid(),
+                responseDto.organisationUuid(),
+                responseDto.courseUuid(),
+                responseDto.programUuid(),
+                responseDto.trainingFee(),
+                responseDto.classVisibility(),
+                responseDto.sessionFormat(),
+                responseDto.defaultStartTime(),
+                responseDto.defaultEndTime(),
+                responseDto.academicPeriodStartDate(),
+                responseDto.academicPeriodEndDate(),
+                responseDto.registrationPeriodStartDate(),
+                responseDto.registrationPeriodEndDate(),
+                responseDto.classReminderMinutes(),
+                responseDto.classColor(),
+                responseDto.locationType(),
+                responseDto.locationName(),
+                responseDto.locationLatitude(),
+                responseDto.locationLongitude(),
+                responseDto.meetingLink(),
+                responseDto.maxParticipants(),
+                responseDto.allowWaitlist(),
+                responseDto.isActive(),
+                responseDto.sessionTemplates(),
+                responseDto.createdDate(),
+                responseDto.updatedDate(),
+                responseDto.createdBy(),
+                responseDto.updatedBy()
+        );
+        MockMultipartFile thumbnail = new MockMultipartFile(
+                "thumbnail",
+                "image.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "image".getBytes()
+        );
+
+        when(classDefinitionService.uploadThumbnail(eq(classUuid), any()))
+                .thenReturn(new ClassDefinitionResponseDTO(responseDto));
+
+        mockMvc.perform(multipart("/api/v1/classes/{uuid}/thumbnail", classUuid)
+                        .file(thumbnail))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.class_definition.thumbnail_url").value(responseDto.thumbnailUrl()));
+    }
+
+    @Test
+    void uploadClassPromotionalVideoReturnsUpdatedClassDefinition() throws Exception {
+        UUID classUuid = UUID.randomUUID();
+        ClassDefinitionDTO responseDto = sampleRequest(UUID.randomUUID(), null, 30, "#1F6FEB");
+        responseDto = new ClassDefinitionDTO(
+                responseDto.uuid(),
+                responseDto.title(),
+                responseDto.description(),
+                responseDto.thumbnailUrl(),
+                "/api/v1/classes/media/class_promotional_videos/" + classUuid + "/promo.mp4",
+                responseDto.defaultInstructorUuid(),
+                responseDto.organisationUuid(),
+                responseDto.courseUuid(),
+                responseDto.programUuid(),
+                responseDto.trainingFee(),
+                responseDto.classVisibility(),
+                responseDto.sessionFormat(),
+                responseDto.defaultStartTime(),
+                responseDto.defaultEndTime(),
+                responseDto.academicPeriodStartDate(),
+                responseDto.academicPeriodEndDate(),
+                responseDto.registrationPeriodStartDate(),
+                responseDto.registrationPeriodEndDate(),
+                responseDto.classReminderMinutes(),
+                responseDto.classColor(),
+                responseDto.locationType(),
+                responseDto.locationName(),
+                responseDto.locationLatitude(),
+                responseDto.locationLongitude(),
+                responseDto.meetingLink(),
+                responseDto.maxParticipants(),
+                responseDto.allowWaitlist(),
+                responseDto.isActive(),
+                responseDto.sessionTemplates(),
+                responseDto.createdDate(),
+                responseDto.updatedDate(),
+                responseDto.createdBy(),
+                responseDto.updatedBy()
+        );
+        MockMultipartFile promotionalVideo = new MockMultipartFile(
+                "promotional_video",
+                "promo.mp4",
+                "video/mp4",
+                "video".getBytes()
+        );
+
+        when(classDefinitionService.uploadPromotionalVideo(eq(classUuid), any()))
+                .thenReturn(new ClassDefinitionResponseDTO(responseDto));
+
+        mockMvc.perform(multipart("/api/v1/classes/{uuid}/promotional-video", classUuid)
+                        .file(promotionalVideo))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.class_definition.promotional_video_url").value(responseDto.promotionalVideoUrl()));
+    }
+
+    @Test
+    void getClassMediaStreamsStoredMedia() throws Exception {
+        String storedPath = "class_thumbnails/class-uuid/image.png";
+        when(storageService.load(storedPath)).thenReturn(new ByteArrayResource("image".getBytes()));
+        when(storageService.getContentType(storedPath)).thenReturn(MediaType.IMAGE_PNG_VALUE);
+
+        mockMvc.perform(get("/api/v1/classes/media/" + storedPath))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", MediaType.IMAGE_PNG_VALUE))
+                .andExpect(header().string("Content-Disposition", "inline; filename=\"image.png\""));
     }
 
     @Test
@@ -330,6 +462,8 @@ class ClassDefinitionControllerTest {
         return new ClassDefinitionUpdateRequestDTO(
                 source.title(),
                 source.description(),
+                source.thumbnailUrl(),
+                source.promotionalVideoUrl(),
                 source.defaultInstructorUuid(),
                 source.organisationUuid(),
                 source.courseUuid(),
@@ -375,6 +509,21 @@ class ClassDefinitionControllerTest {
         @Bean
         RequestAuditService requestAuditService() {
             return Mockito.mock(RequestAuditService.class);
+        }
+
+        @Bean
+        StorageService storageService() {
+            return Mockito.mock(StorageService.class);
+        }
+
+        @Bean
+        StorageProperties storageProperties() {
+            StorageProperties storageProperties = new StorageProperties();
+            StorageProperties.Folders folders = new StorageProperties.Folders();
+            folders.setClassThumbnails("class_thumbnails");
+            folders.setClassPromotionalVideos("class_promotional_videos");
+            storageProperties.setFolders(folders);
+            return storageProperties;
         }
     }
 }

--- a/src/test/java/apps/sarafrika/elimika/classes/service/impl/ClassDefinitionServiceImplTest.java
+++ b/src/test/java/apps/sarafrika/elimika/classes/service/impl/ClassDefinitionServiceImplTest.java
@@ -5,6 +5,7 @@ import apps.sarafrika.elimika.classes.dto.ClassDefinitionDTO;
 import apps.sarafrika.elimika.classes.dto.ClassDefinitionResponseDTO;
 import apps.sarafrika.elimika.classes.dto.ClassRecurrenceDTO;
 import apps.sarafrika.elimika.classes.dto.ClassSessionTemplateDTO;
+import apps.sarafrika.elimika.classes.internal.ClassMediaValidationService;
 import apps.sarafrika.elimika.classes.model.ClassDefinition;
 import apps.sarafrika.elimika.classes.model.ClassSessionTemplate;
 import apps.sarafrika.elimika.classes.repository.ClassDefinitionRepository;
@@ -18,6 +19,8 @@ import apps.sarafrika.elimika.shared.enums.ClassVisibility;
 import apps.sarafrika.elimika.shared.enums.LocationType;
 import apps.sarafrika.elimika.shared.enums.SessionFormat;
 import apps.sarafrika.elimika.shared.spi.ClassScheduleService;
+import apps.sarafrika.elimika.shared.storage.config.StorageProperties;
+import apps.sarafrika.elimika.shared.storage.service.StorageService;
 import apps.sarafrika.elimika.timetabling.spi.ScheduleRequestDTO;
 import apps.sarafrika.elimika.timetabling.spi.ScheduledInstanceDTO;
 import apps.sarafrika.elimika.timetabling.spi.SchedulingStatus;
@@ -29,6 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.mock.web.MockMultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -75,10 +79,24 @@ class ClassDefinitionServiceImplTest {
     @Mock
     private TimetableService timetableService;
 
+    @Mock
+    private StorageService storageService;
+
+    @Mock
+    private ClassMediaValidationService classMediaValidationService;
+
+    private StorageProperties storageProperties;
+
     private ClassDefinitionServiceImpl service;
 
     @BeforeEach
     void setUp() {
+        storageProperties = new StorageProperties();
+        StorageProperties.Folders folders = new StorageProperties.Folders();
+        folders.setClassThumbnails("class_thumbnails");
+        folders.setClassPromotionalVideos("class_promotional_videos");
+        storageProperties.setFolders(folders);
+
         service = new ClassDefinitionServiceImpl(
                 classDefinitionRepository,
                 classSchedulingConflictRepository,
@@ -88,7 +106,10 @@ class ClassDefinitionServiceImplTest {
                 courseInfoService,
                 courseTrainingApprovalSpi,
                 timetableServiceProvider,
-                classScheduleServiceProvider
+                classScheduleServiceProvider,
+                storageService,
+                storageProperties,
+                classMediaValidationService
         );
     }
 
@@ -157,6 +178,52 @@ class ClassDefinitionServiceImplTest {
         ClassSessionTemplateDTO resultTemplate = response.classDefinition().sessionTemplates().getFirst();
         assertThat(resultTemplate.uuid()).isEqualTo(template.getUuid());
         assertThat(resultTemplate.recurrence().recurrenceType()).isEqualTo(ClassRecurrenceDTO.RecurrenceType.WEEKLY);
+    }
+
+    @Test
+    void uploadThumbnailStoresInClassFolderAndPersistsMediaUrl() {
+        UUID classUuid = UUID.randomUUID();
+        ClassDefinition entity = sampleClassDefinitionEntity();
+        entity.setUuid(classUuid);
+        MockMultipartFile file = new MockMultipartFile("thumbnail", "image.png", "image/png", "image".getBytes());
+        String storedPath = "class_thumbnails/" + classUuid + "/generated.png";
+
+        when(classDefinitionRepository.findByUuid(classUuid)).thenReturn(Optional.of(entity));
+        when(storageService.store(file, "class_thumbnails/" + classUuid)).thenReturn(storedPath);
+        when(classDefinitionRepository.save(any(ClassDefinition.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(classSessionTemplateRepository.findByClassDefinitionUuidOrderByTemplateOrderAscCreatedDateAsc(classUuid))
+                .thenReturn(List.of());
+
+        ClassDefinitionResponseDTO response = service.uploadThumbnail(classUuid, file);
+
+        assertThat(response.classDefinition().thumbnailUrl())
+                .isEqualTo("/api/v1/classes/media/class_thumbnails/" + classUuid + "/generated.png");
+        assertThat(entity.getThumbnailUrl()).isEqualTo(response.classDefinition().thumbnailUrl());
+        verify(classMediaValidationService).validateThumbnail(file);
+        verify(storageService).store(file, "class_thumbnails/" + classUuid);
+    }
+
+    @Test
+    void uploadPromotionalVideoStoresInClassFolderAndPersistsMediaUrl() {
+        UUID classUuid = UUID.randomUUID();
+        ClassDefinition entity = sampleClassDefinitionEntity();
+        entity.setUuid(classUuid);
+        MockMultipartFile file = new MockMultipartFile("promotional_video", "promo.mp4", "video/mp4", "video".getBytes());
+        String storedPath = "class_promotional_videos/" + classUuid + "/generated.mp4";
+
+        when(classDefinitionRepository.findByUuid(classUuid)).thenReturn(Optional.of(entity));
+        when(storageService.store(file, "class_promotional_videos/" + classUuid)).thenReturn(storedPath);
+        when(classDefinitionRepository.save(any(ClassDefinition.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(classSessionTemplateRepository.findByClassDefinitionUuidOrderByTemplateOrderAscCreatedDateAsc(classUuid))
+                .thenReturn(List.of());
+
+        ClassDefinitionResponseDTO response = service.uploadPromotionalVideo(classUuid, file);
+
+        assertThat(response.classDefinition().promotionalVideoUrl())
+                .isEqualTo("/api/v1/classes/media/class_promotional_videos/" + classUuid + "/generated.mp4");
+        assertThat(entity.getPromotionalVideoUrl()).isEqualTo(response.classDefinition().promotionalVideoUrl());
+        verify(classMediaValidationService).validatePromotionalVideo(file);
+        verify(storageService).store(file, "class_promotional_videos/" + classUuid);
     }
 
     private ClassDefinitionDTO sampleClassDefinition() {


### PR DESCRIPTION
## Summary

Adds class thumbnail and promotional video support for instructor class creation workflows.

## Changes

- Adds `thumbnail_url` and `promotional_video_url` columns to `class_definitions`.
- Exposes the media URLs through class create, update, get, and list response DTOs.
- Adds class thumbnail and promotional video upload endpoints.
- Adds class media streaming under `/api/v1/classes/media/{*filePath}`.
- Adds class-specific storage folders and validation for image and video uploads.

## Tests

- `/usr/bin/env JAVA_HOME=/home/willy/.jdks/temurin-21.0.11 ./gradlew test`

## Configuration/Secret Impacts

- Adds optional storage folder overrides:
  - `CLASS_THUMBNAILS_FOLDER`
  - `CLASS_PROMOTIONAL_VIDEOS_FOLDER`
- No secret changes.
