### PR TITLE
fix: return 404 for unknown routes and 400 for parameter type mismatches instead of 500

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/shared/config/GlobalExceptionHandler.java
+++ b/src/main/java/apps/sarafrika/elimika/shared/config/GlobalExceptionHandler.java
@@ -26,7 +26,9 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.Locale;
 import java.util.Map;
@@ -223,6 +225,37 @@ public class GlobalExceptionHandler {
         log.error("Identity provider error [errorId={}]", errorId, ex);
         return ResponseEntity.status(HttpStatus.BAD_GATEWAY)
                 .body(ApiResponse.error("Identity provider request failed", ex.getMessage()));
+    }
+
+    /**
+     * Handles requests for paths that do not match any endpoint.
+     * Without this, unknown routes fall into the generic handler and surface
+     * as 500 "unexpected error" instead of 404, hiding client-side URL bugs.
+     */
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleNoResourceFoundException(NoResourceFoundException ex) {
+        log.debug("No endpoint for path: {}", ex.getResourcePath());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.error("Resource not found", "No endpoint: " + ex.getResourcePath()));
+    }
+
+    /**
+     * Handles request parameters/path variables that cannot be converted to
+     * the declared type (e.g. a datetime sent where a date is expected, or a
+     * non-UUID value in a UUID path segment). These are client errors and
+     * must surface as 400 with an actionable message, not a generic 500.
+     */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException ex) {
+        String requiredType = ex.getRequiredType() != null
+                ? ex.getRequiredType().getSimpleName()
+                : "the expected type";
+        String message = String.format("Parameter '%s' has invalid value '%s' (expected %s)",
+                ex.getName(), ex.getValue(), requiredType);
+        log.debug("Request parameter type mismatch: {}", message);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiResponse.error("Invalid request parameter", message));
     }
 
     /**

--- a/src/test/java/apps/sarafrika/elimika/classes/controller/ClassDefinitionControllerTest.java
+++ b/src/test/java/apps/sarafrika/elimika/classes/controller/ClassDefinitionControllerTest.java
@@ -526,4 +526,20 @@ class ClassDefinitionControllerTest {
             return storageProperties;
         }
     }
+    @Test
+    void invalidUuidPathSegmentReturnsBadRequestNotServerError() throws Exception {
+        mockMvc.perform(get("/api/v1/classes/instructor/{instructorUuid}", "not-a-uuid"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Invalid request parameter"));
+    }
+
+    @Test
+    void unknownPathReturnsNotFoundNotServerError() throws Exception {
+        mockMvc.perform(get("/api/v1/classes/{uuid}/no-such-resource/extra", UUID.randomUUID()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Resource not found"));
+    }
+
 }


### PR DESCRIPTION
## Summary

During a full performance audit of the UI against staging, every client-side URL or parameter mistake surfaced as **HTTP 500 \"An unexpected error occurred\"**, which sent the investigation down a false \"backend is broken\" trail and triggers React Query retry storms in the frontend (3 retries × every malformed request).

The staging logs showed the catch-all `Exception` handler swallowing two specific, client-attributable cases (56 occurrences):
- `NoResourceFoundException` — unknown paths (e.g. `/api/v1/instructors/{uuid}/class-definitions`, which doesn't exist) → should be **404**
- `MethodArgumentTypeMismatchException` — e.g. an ISO datetime sent where `LocalDate` is expected, or a literal `{courseUuid}` placeholder in a UUID segment → should be **400** with an actionable message

## Changes

- `GlobalExceptionHandler`: dedicated handlers for both exceptions (404 / 400), keeping the generic 500 handler for genuinely unexpected errors.
- Regression tests in `ClassDefinitionControllerTest` asserting the new statuses.

## Verification

- `./gradlew test --tests ClassDefinitionControllerTest` passes (incl. 2 new tests).
- The corresponding client bugs (unsubstituted path placeholders, datetime-vs-date params) are fixed separately in elimika-ui (sarafrika/elimika-ui#349).