### PR TITLE
fix(notifications): UTC timestamp contract and per-domain inbox scoping

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/notifications/api/NotificationEvent.java
+++ b/src/main/java/apps/sarafrika/elimika/notifications/api/NotificationEvent.java
@@ -76,6 +76,16 @@ public interface NotificationEvent {
     }
 
     /**
+     * The user domain (dashboard role) this notification is addressed to, so a
+     * multi-domain recipient's inbox can be scoped to the active dashboard.
+     * Defaults to {@code null}, in which case the notification type's default
+     * audience ({@link NotificationType#getRecipientDomain()}) is used.
+     */
+    default String getRecipientDomain() {
+        return null;
+    }
+
+    /**
      * In-app title. Defaults to the notification type display name.
      */
     default String getTitle() {

--- a/src/main/java/apps/sarafrika/elimika/notifications/api/NotificationType.java
+++ b/src/main/java/apps/sarafrika/elimika/notifications/api/NotificationType.java
@@ -141,4 +141,63 @@ public enum NotificationType {
     public String getEmailTemplatePath() {
         return "email/" + templateName + ".html";
     }
+
+    /**
+     * The user domain (dashboard role) this notification type is addressed to.
+     * <p>
+     * A user may hold several domains (e.g. student and instructor) but share a
+     * single recipient identity. This mapping lets the inbox be scoped to the
+     * active dashboard and lets the UI build click-through links against the
+     * correct domain. Account-level types that are relevant regardless of the
+     * active dashboard return {@code null}, meaning "all domains".
+     */
+    public String getRecipientDomain() {
+        return switch (this) {
+            case COURSE_ENROLLMENT_WELCOME,
+                 COURSE_COMPLETION_CERTIFICATE,
+                 LEARNING_MILESTONE_ACHIEVED,
+                 ASSIGNMENT_DUE_REMINDER,
+                 ASSIGNMENT_SUBMITTED_CONFIRMATION,
+                 ASSIGNMENT_GRADED,
+                 ASSIGNMENT_RETURNED_FOR_REVISION,
+                 ASSIGNMENT_DEADLINE_REMINDER,
+                 ASSESSMENT_COMPLETED,
+                 CLASS_ENROLLMENT_CONFIRMED,
+                 UPCOMING_CLASS_REMINDER,
+                 LEARNING_CERTIFICATE_ISSUED,
+                 WEEKLY_PROGRESS_SUMMARY,
+                 LEARNING_STREAK_ACHIEVEMENT,
+                 PEER_ACHIEVEMENT_CELEBRATION -> "student";
+
+            case NEW_STUDENT_ENROLLMENT,
+                 NEW_ASSIGNMENT_SUBMISSION,
+                 CLASS_SCHEDULE_UPDATED,
+                 GRADING_REMINDER,
+                 INSTRUCTOR_CLASS_ENROLLMENT_MILESTONE,
+                 INSTRUCTOR_CLASS_ENROLLMENT_NOTICE,
+                 COURSE_TRAINING_APPLICATION_APPROVED,
+                 COURSE_TRAINING_APPLICATION_REJECTED,
+                 COURSE_TRAINING_APPLICATION_REVOKED,
+                 PROGRAM_TRAINING_APPLICATION_APPROVED,
+                 PROGRAM_TRAINING_APPLICATION_REJECTED,
+                 PROGRAM_TRAINING_APPLICATION_REVOKED -> "instructor";
+
+            case COURSE_CONTENT_APPROVED,
+                 COURSE_CONTENT_REJECTED,
+                 PROGRAM_CONTENT_APPROVED,
+                 PROGRAM_CONTENT_REJECTED,
+                 COURSE_TRAINING_APPLICATION_SUBMITTED,
+                 PROGRAM_TRAINING_APPLICATION_SUBMITTED,
+                 COURSE_ENROLLMENT_MILESTONE,
+                 COURSE_ENROLLMENT_NOTICE -> "course_creator";
+
+            // Account-level notifications are relevant in every dashboard.
+            case ACCOUNT_CREATED,
+                 PASSWORD_RESET_REQUEST,
+                 SECURITY_ALERT,
+                 ORDER_PAYMENT_RECEIPT,
+                 PROFILE_DOCUMENT_VERIFIED,
+                 PROFILE_COMPLETION_REMINDER -> null;
+        };
+    }
 }

--- a/src/main/java/apps/sarafrika/elimika/notifications/controller/NotificationController.java
+++ b/src/main/java/apps/sarafrika/elimika/notifications/controller/NotificationController.java
@@ -43,6 +43,7 @@ public class NotificationController {
     @GetMapping
     @Operation(summary = "List current user's notifications")
     public ResponseEntity<ApiResponse<PagedDTO<NotificationDTO>>> listNotifications(
+            @RequestParam(required = false) String domain,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String presentation,
             @RequestParam(required = false) String type,
@@ -52,6 +53,7 @@ public class NotificationController {
         UUID recipientUuid = userContextService.getCurrentUserUuid();
         Page<NotificationDTO> notifications = userNotificationService.listNotifications(
                 recipientUuid,
+                domain,
                 parseStatus(status),
                 parsePresentation(presentation),
                 parseType(type),
@@ -67,8 +69,10 @@ public class NotificationController {
 
     @GetMapping("/counts")
     @Operation(summary = "Get current user's notification counts")
-    public ResponseEntity<ApiResponse<NotificationCountsDTO>> getCounts() {
-        NotificationCountsDTO counts = userNotificationService.getCounts(userContextService.getCurrentUserUuid());
+    public ResponseEntity<ApiResponse<NotificationCountsDTO>> getCounts(
+            @RequestParam(required = false) String domain
+    ) {
+        NotificationCountsDTO counts = userNotificationService.getCounts(userContextService.getCurrentUserUuid(), domain);
         return ResponseEntity.ok(ApiResponse.success(counts, "Notification counts retrieved successfully"));
     }
 
@@ -90,12 +94,14 @@ public class NotificationController {
     @Operation(summary = "Apply a bulk notification action")
     public ResponseEntity<ApiResponse<NotificationActionResultDTO>> applyBulkAction(
             @RequestParam("action") String action,
+            @RequestParam(required = false) String domain,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) String presentation,
             @RequestParam(required = false) String type
     ) {
         NotificationActionResultDTO result = userNotificationService.applyBulkAction(
                 userContextService.getCurrentUserUuid(),
+                domain,
                 action,
                 parseStatus(status),
                 parsePresentation(presentation),

--- a/src/main/java/apps/sarafrika/elimika/notifications/dto/NotificationDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/notifications/dto/NotificationDTO.java
@@ -16,6 +16,8 @@ public record NotificationDTO(
         UUID uuid,
         @JsonProperty("notification_id")
         UUID notificationId,
+        @JsonProperty("recipient_domain")
+        String recipientDomain,
         @JsonProperty("type")
         NotificationType type,
         @JsonProperty("category")

--- a/src/main/java/apps/sarafrika/elimika/notifications/dto/NotificationDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/notifications/dto/NotificationDTO.java
@@ -7,7 +7,7 @@ import apps.sarafrika.elimika.notifications.api.NotificationType;
 import apps.sarafrika.elimika.notifications.api.UserNotificationStatus;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.UUID;
 
@@ -35,14 +35,14 @@ public record NotificationDTO(
         @JsonProperty("metadata")
         Map<String, Object> metadata,
         @JsonProperty("occurred_at")
-        LocalDateTime occurredAt,
+        OffsetDateTime occurredAt,
         @JsonProperty("popup_seen_at")
-        LocalDateTime popupSeenAt,
+        OffsetDateTime popupSeenAt,
         @JsonProperty("read_at")
-        LocalDateTime readAt,
+        OffsetDateTime readAt,
         @JsonProperty("archived_at")
-        LocalDateTime archivedAt,
+        OffsetDateTime archivedAt,
         @JsonProperty("created_at")
-        LocalDateTime createdAt
+        OffsetDateTime createdAt
 ) {
 }

--- a/src/main/java/apps/sarafrika/elimika/notifications/model/UserNotification.java
+++ b/src/main/java/apps/sarafrika/elimika/notifications/model/UserNotification.java
@@ -38,6 +38,9 @@ public class UserNotification extends BaseEntity {
     @Column(name = "recipient_uuid")
     private UUID recipientUuid;
 
+    @Column(name = "recipient_domain")
+    private String recipientDomain;
+
     @Column(name = "notification_id")
     private UUID notificationId;
 
@@ -91,6 +94,7 @@ public class UserNotification extends BaseEntity {
 
     public static UserNotification create(
             UUID recipientUuid,
+            String recipientDomain,
             UUID notificationId,
             NotificationType notificationType,
             NotificationPriority priority,
@@ -104,6 +108,7 @@ public class UserNotification extends BaseEntity {
     ) {
         UserNotification notification = new UserNotification();
         notification.setRecipientUuid(recipientUuid);
+        notification.setRecipientDomain(recipientDomain);
         notification.setNotificationId(notificationId);
         notification.setNotificationType(notificationType);
         notification.setCategory(notificationType.getCategory());

--- a/src/main/java/apps/sarafrika/elimika/notifications/model/UserNotificationRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/notifications/model/UserNotificationRepository.java
@@ -25,14 +25,6 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
 
     Page<UserNotification> findByRecipientUuid(UUID recipientUuid, Pageable pageable);
 
-    long countByRecipientUuidAndStatus(UUID recipientUuid, UserNotificationStatus status);
-
-    long countByRecipientUuidAndStatusAndPresentationAndPopupSeenAtIsNull(
-            UUID recipientUuid,
-            UserNotificationStatus status,
-            NotificationPresentation presentation
-    );
-
     @Modifying
     @Query("""
             UPDATE UserNotification n
@@ -40,11 +32,13 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
                    n.readAt = COALESCE(n.readAt, :readAt)
              WHERE n.recipientUuid = :recipientUuid
                AND n.status = :unreadStatus
+               AND (:domain IS NULL OR n.recipientDomain = :domain OR n.recipientDomain IS NULL)
                AND (:type IS NULL OR n.notificationType = :type)
                AND (:presentation IS NULL OR n.presentation = :presentation)
             """)
     int markUnreadAsRead(
             @Param("recipientUuid") UUID recipientUuid,
+            @Param("domain") String domain,
             @Param("type") NotificationType type,
             @Param("presentation") NotificationPresentation presentation,
             @Param("unreadStatus") UserNotificationStatus unreadStatus,

--- a/src/main/java/apps/sarafrika/elimika/notifications/service/UserNotificationService.java
+++ b/src/main/java/apps/sarafrika/elimika/notifications/service/UserNotificationService.java
@@ -17,6 +17,7 @@ public interface UserNotificationService {
 
     Page<NotificationDTO> listNotifications(
             UUID recipientUuid,
+            String domain,
             UserNotificationStatus status,
             NotificationPresentation presentation,
             NotificationType type,
@@ -24,12 +25,13 @@ public interface UserNotificationService {
             Pageable pageable
     );
 
-    NotificationCountsDTO getCounts(UUID recipientUuid);
+    NotificationCountsDTO getCounts(UUID recipientUuid, String domain);
 
     NotificationDTO applyAction(UUID recipientUuid, UUID notificationUuid, String action);
 
     NotificationActionResultDTO applyBulkAction(
             UUID recipientUuid,
+            String domain,
             String action,
             UserNotificationStatus status,
             NotificationPresentation presentation,

--- a/src/main/java/apps/sarafrika/elimika/notifications/service/impl/UserNotificationServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/notifications/service/impl/UserNotificationServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -197,12 +198,21 @@ public class UserNotificationServiceImpl implements UserNotificationService {
                 notification.getBody(),
                 notification.getActionUrl(),
                 readMetadata(notification.getMetadataJson()),
-                notification.getOccurredAt(),
-                notification.getPopupSeenAt(),
-                notification.getReadAt(),
-                notification.getArchivedAt(),
-                notification.getCreatedDate()
+                toUtcOffset(notification.getOccurredAt()),
+                toUtcOffset(notification.getPopupSeenAt()),
+                toUtcOffset(notification.getReadAt()),
+                toUtcOffset(notification.getArchivedAt()),
+                toUtcOffset(notification.getCreatedDate())
         );
+    }
+
+    /**
+     * Stamp a stored {@link LocalDateTime} (persisted in UTC) with an explicit
+     * UTC offset so the API emits an unambiguous instant (e.g. {@code ...Z})
+     * instead of a zone-less timestamp that clients would misread as local time.
+     */
+    private OffsetDateTime toUtcOffset(LocalDateTime value) {
+        return value == null ? null : value.atOffset(ZoneOffset.UTC);
     }
 
     private String resolveDedupeKey(NotificationEvent event) {

--- a/src/main/java/apps/sarafrika/elimika/notifications/service/impl/UserNotificationServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/notifications/service/impl/UserNotificationServiceImpl.java
@@ -68,6 +68,7 @@ public class UserNotificationServiceImpl implements UserNotificationService {
 
         UserNotification notification = UserNotification.create(
                 event.getRecipientId(),
+                resolveRecipientDomain(event),
                 event.getNotificationId(),
                 event.getNotificationType(),
                 event.getPriority() != null ? event.getPriority() : NotificationPriority.NORMAL,
@@ -87,6 +88,7 @@ public class UserNotificationServiceImpl implements UserNotificationService {
     @Transactional(readOnly = true)
     public Page<NotificationDTO> listNotifications(
             UUID recipientUuid,
+            String domain,
             UserNotificationStatus status,
             NotificationPresentation presentation,
             NotificationType type,
@@ -94,22 +96,19 @@ public class UserNotificationServiceImpl implements UserNotificationService {
             Pageable pageable
     ) {
         return userNotificationRepository.findAll(
-                filter(recipientUuid, status, presentation, type, popupSeen),
+                filter(recipientUuid, domain, status, presentation, type, popupSeen),
                 pageable
         ).map(this::toDTO);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public NotificationCountsDTO getCounts(UUID recipientUuid) {
-        long unreadCount = userNotificationRepository.countByRecipientUuidAndStatus(
-                recipientUuid,
-                UserNotificationStatus.UNREAD
+    public NotificationCountsDTO getCounts(UUID recipientUuid, String domain) {
+        long unreadCount = userNotificationRepository.count(
+                filter(recipientUuid, domain, UserNotificationStatus.UNREAD, null, null, null)
         );
-        long popupCount = userNotificationRepository.countByRecipientUuidAndStatusAndPresentationAndPopupSeenAtIsNull(
-                recipientUuid,
-                UserNotificationStatus.UNREAD,
-                NotificationPresentation.POPUP
+        long popupCount = userNotificationRepository.count(
+                filter(recipientUuid, domain, UserNotificationStatus.UNREAD, NotificationPresentation.POPUP, null, false)
         );
         return new NotificationCountsDTO(unreadCount, popupCount);
     }
@@ -134,6 +133,7 @@ public class UserNotificationServiceImpl implements UserNotificationService {
     @Override
     public NotificationActionResultDTO applyBulkAction(
             UUID recipientUuid,
+            String domain,
             String action,
             UserNotificationStatus status,
             NotificationPresentation presentation,
@@ -146,6 +146,7 @@ public class UserNotificationServiceImpl implements UserNotificationService {
 
         int affected = userNotificationRepository.markUnreadAsRead(
                 recipientUuid,
+                normalizeDomain(domain),
                 type,
                 presentation,
                 UserNotificationStatus.UNREAD,
@@ -157,14 +158,24 @@ public class UserNotificationServiceImpl implements UserNotificationService {
 
     private Specification<UserNotification> filter(
             UUID recipientUuid,
+            String domain,
             UserNotificationStatus status,
             NotificationPresentation presentation,
             NotificationType type,
             Boolean popupSeen
     ) {
+        String normalizedDomain = normalizeDomain(domain);
         return (root, query, criteriaBuilder) -> {
             var predicates = new ArrayList<Predicate>();
             predicates.add(criteriaBuilder.equal(root.get("recipientUuid"), recipientUuid));
+            if (normalizedDomain != null) {
+                // Domain-scoped inbox: show this domain's notifications plus
+                // account-level ones (null domain) that apply everywhere.
+                predicates.add(criteriaBuilder.or(
+                        criteriaBuilder.equal(root.get("recipientDomain"), normalizedDomain),
+                        criteriaBuilder.isNull(root.get("recipientDomain"))
+                ));
+            }
             if (status != null) {
                 predicates.add(criteriaBuilder.equal(root.get("status"), status));
             }
@@ -189,6 +200,7 @@ public class UserNotificationServiceImpl implements UserNotificationService {
         return new NotificationDTO(
                 notification.getUuid(),
                 notification.getNotificationId(),
+                notification.getRecipientDomain(),
                 notification.getNotificationType(),
                 notification.getCategory(),
                 notification.getPriority(),
@@ -213,6 +225,29 @@ public class UserNotificationServiceImpl implements UserNotificationService {
      */
     private OffsetDateTime toUtcOffset(LocalDateTime value) {
         return value == null ? null : value.atOffset(ZoneOffset.UTC);
+    }
+
+    /**
+     * The dashboard domain this notification is addressed to: an explicit
+     * per-event override when present, otherwise the notification type's
+     * default audience. {@code null} means the notification applies to every
+     * domain the recipient holds.
+     */
+    private String resolveRecipientDomain(NotificationEvent event) {
+        String override = normalizeDomain(event.getRecipientDomain());
+        if (override != null) {
+            return override;
+        }
+        return normalizeDomain(event.getNotificationType().getRecipientDomain());
+    }
+
+    private String normalizeDomain(String domain) {
+        if (!StringUtils.hasText(domain)) {
+            return null;
+        }
+        String normalized = domain.trim().toLowerCase();
+        // Tolerate the British/American spelling split used across the app.
+        return "organization".equals(normalized) ? "organisation" : normalized;
     }
 
     private String resolveDedupeKey(NotificationEvent event) {

--- a/src/main/resources/db/migration/V202607091000__add_recipient_domain_to_user_notifications.sql
+++ b/src/main/resources/db/migration/V202607091000__add_recipient_domain_to_user_notifications.sql
@@ -1,0 +1,58 @@
+-- Scope in-app notifications to the dashboard domain (role) they are addressed
+-- to, so a multi-domain recipient (e.g. student + instructor) sees each
+-- notification only in the relevant dashboard. NULL means "all domains".
+
+ALTER TABLE user_notifications
+    ADD COLUMN recipient_domain VARCHAR(30);
+
+-- Backfill existing rows from the notification type's default audience,
+-- mirroring NotificationType.getRecipientDomain(). Account-level types are
+-- left NULL so they continue to appear in every dashboard.
+UPDATE user_notifications
+SET recipient_domain = CASE
+    WHEN notification_type IN (
+        'COURSE_ENROLLMENT_WELCOME',
+        'COURSE_COMPLETION_CERTIFICATE',
+        'LEARNING_MILESTONE_ACHIEVED',
+        'ASSIGNMENT_DUE_REMINDER',
+        'ASSIGNMENT_SUBMITTED_CONFIRMATION',
+        'ASSIGNMENT_GRADED',
+        'ASSIGNMENT_RETURNED_FOR_REVISION',
+        'ASSIGNMENT_DEADLINE_REMINDER',
+        'ASSESSMENT_COMPLETED',
+        'CLASS_ENROLLMENT_CONFIRMED',
+        'UPCOMING_CLASS_REMINDER',
+        'LEARNING_CERTIFICATE_ISSUED',
+        'WEEKLY_PROGRESS_SUMMARY',
+        'LEARNING_STREAK_ACHIEVEMENT',
+        'PEER_ACHIEVEMENT_CELEBRATION'
+    ) THEN 'student'
+    WHEN notification_type IN (
+        'NEW_STUDENT_ENROLLMENT',
+        'NEW_ASSIGNMENT_SUBMISSION',
+        'CLASS_SCHEDULE_UPDATED',
+        'GRADING_REMINDER',
+        'INSTRUCTOR_CLASS_ENROLLMENT_MILESTONE',
+        'INSTRUCTOR_CLASS_ENROLLMENT_NOTICE',
+        'COURSE_TRAINING_APPLICATION_APPROVED',
+        'COURSE_TRAINING_APPLICATION_REJECTED',
+        'COURSE_TRAINING_APPLICATION_REVOKED',
+        'PROGRAM_TRAINING_APPLICATION_APPROVED',
+        'PROGRAM_TRAINING_APPLICATION_REJECTED',
+        'PROGRAM_TRAINING_APPLICATION_REVOKED'
+    ) THEN 'instructor'
+    WHEN notification_type IN (
+        'COURSE_CONTENT_APPROVED',
+        'COURSE_CONTENT_REJECTED',
+        'PROGRAM_CONTENT_APPROVED',
+        'PROGRAM_CONTENT_REJECTED',
+        'COURSE_TRAINING_APPLICATION_SUBMITTED',
+        'PROGRAM_TRAINING_APPLICATION_SUBMITTED',
+        'COURSE_ENROLLMENT_MILESTONE',
+        'COURSE_ENROLLMENT_NOTICE'
+    ) THEN 'course_creator'
+    ELSE NULL
+END;
+
+CREATE INDEX idx_user_notifications_recipient_domain
+    ON user_notifications (recipient_uuid, recipient_domain, status);


### PR DESCRIPTION
## Summary
Two related fixes to the notifications module.

### 1. Timezone-correct timestamp contract
`NotificationDTO` timestamps were serialized as zone-less `LocalDateTime`, so clients read UTC instants as local time (off by the viewer's offset). Switched the five timestamp fields to `OffsetDateTime`, stamped `+00:00` in the mapper — the API now emits unambiguous instants (matches the existing `OrderResponse` convention).

### 2. Per-domain inbox scoping
A user who holds several domains (e.g. student + instructor) shared one recipient identity, so every dashboard showed all their notifications and click-through links misrouted.

- `NotificationType.getRecipientDomain()` — canonical type→domain map (student / instructor / course_creator; account-level types → `null` = all domains).
- `NotificationEvent.getRecipientDomain()` override hook for publishers that need to override the type default.
- New `user_notifications.recipient_domain` column + migration `V202607091000` that backfills existing rows from the same map and indexes `(recipient_uuid, recipient_domain, status)`.
- List / counts / bulk "mark all read" filter with `recipient_domain = :domain OR recipient_domain IS NULL`, so each dashboard shows its own notifications plus account-level ones.
- `domain` query param added to `GET /notifications`, `GET /counts`, and the bulk `POST /notifications`; `recipient_domain` exposed on the DTO.

## Verification
- `./gradlew compileJava` — passes (JDK 21).
- `./gradlew test --tests "apps.sarafrika.elimika.notifications.*"` — passes.
