### PR TITLE
feat(courses): review edits to published courses without unpublishing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,26 @@
 # Elimika
 
 ## Overview
-Elimika is Sarafrika's modular learning platform backend. It orchestrates courses, classes, organizations, and learner experiences while handling authentication, scheduling, and commerce in one Spring Boot 3.5 service targeting Java 21. Publishing a course or class automatically syncs it to the public catalogue and Medusa commerce stack, keeping storefront data consistent without manual API calls.
+Elimika is Sarafrika's modular learning platform backend. It orchestrates courses, classes, organizations, and learner experiences while handling authentication, scheduling, and commerce in one Spring Boot 3.5 service targeting Java 21. Publishing a course or class automatically syncs it to the public catalogue, keeping storefront data consistent without manual API calls.
 
 ## Core Capabilities
 - Domain-driven modules for courses, class definitions, timetabling, availability, and assessments
 - Organization, instructor, and student domains with Keycloak-backed identity and role management
-- Commerce workflows that generate paywalls, track purchases, and push catalogue data to Medusa
+- Commerce workflows that generate paywalls, track purchases, and maintain the internal catalogue
 - Notification and email services for enrollment, invitations, and progress updates
 - Flyway-managed PostgreSQL schema migrations and storage helpers for media assets
 
 ## Architecture & Stack
-The service runs on Spring Boot with Spring Modulith, Jakarta Validation, and JPA/Hibernate. Authentication uses Keycloak 26+, while payments and catalogue operations integrate with Medusa. Persistent data lives in PostgreSQL; Flyway migrations under `src/main/resources/db/migration` execute on startup. Semantic-release (pnpm) automates versioning and changelog updates.
+The service runs on Spring Boot with Spring Modulith, Jakarta Validation, and JPA/Hibernate. Authentication uses Keycloak 26+. Payments and catalogue operations are handled in-house by the `commerce` module against internal tables (`commerce_product`, `commerce_product_variant`, `commerce_catalogue_item`); there is no external commerce dependency. Persistent data lives in PostgreSQL; Flyway migrations under `src/main/resources/db/migration` execute on startup. Semantic-release (pnpm) automates versioning and changelog updates.
 
 ## Prerequisites
 - Java 21 runtime (the Gradle wrapper manages builds)
-- Docker & Docker Compose for local infrastructure (PostgreSQL, Keycloak, Medusa)
+- Docker & Docker Compose for local infrastructure (PostgreSQL, Keycloak)
 - pnpm 10+ for release automation tasks
 - Node 20+/pnpm only required if you plan to run `pnpm release` locally
 
 ## Local Development
-1. Clone the repository and create a `.env` file with database, Keycloak, encryption, and Medusa credentials. Use `install.md` as a reference template.
+1. Clone the repository and create a `.env` file with database, Keycloak, and encryption credentials. Use `install.md` as a reference template.
 2. Provision dependencies with Docker (PostgreSQL + Keycloak + Elimika) or reuse existing infrastructure. The guide in `install.md` includes ready-to-run `docker-compose` instructions.
 3. Generate the external Docker network used by the stack if it does not already exist: `docker network create sarafrika`.
 4. Start the backing services: `docker compose -f docker/compose.yaml up -d` (or the extended compose file from `install.md`).

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,11 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.modulith:spring-modulith-starter-test'
+	testImplementation 'org.springframework.boot:spring-boot-testcontainers'
+	testImplementation 'org.testcontainers:junit-jupiter'
+	testImplementation 'org.testcontainers:postgresql'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testRuntimeOnly 'org.postgresql:postgresql'
 
 	constraints {
 		implementation 'commons-io:commons-io:2.22.0'

--- a/src/main/java/apps/sarafrika/elimika/course/controller/admin/ContentApprovalAdminController.java
+++ b/src/main/java/apps/sarafrika/elimika/course/controller/admin/ContentApprovalAdminController.java
@@ -1,9 +1,13 @@
 package apps.sarafrika.elimika.course.controller.admin;
 
+import apps.sarafrika.elimika.course.dto.ContentModerationDecisionRequest;
 import apps.sarafrika.elimika.course.dto.ContentModerationHistoryDTO;
 import apps.sarafrika.elimika.course.dto.CourseDTO;
+import apps.sarafrika.elimika.course.dto.CourseEditDiffDTO;
+import apps.sarafrika.elimika.course.dto.CoursePendingEditDTO;
 import apps.sarafrika.elimika.course.dto.TrainingProgramDTO;
 import apps.sarafrika.elimika.course.service.ContentModerationHistoryService;
+import apps.sarafrika.elimika.course.service.CoursePendingEditService;
 import apps.sarafrika.elimika.course.service.CourseService;
 import apps.sarafrika.elimika.course.service.TrainingProgramService;
 import apps.sarafrika.elimika.course.util.enums.ModerationAction;
@@ -11,7 +15,11 @@ import apps.sarafrika.elimika.course.util.enums.ModerationContentType;
 import apps.sarafrika.elimika.shared.dto.ApiResponse;
 import apps.sarafrika.elimika.shared.dto.PagedDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
@@ -25,6 +33,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
@@ -40,9 +49,19 @@ public class ContentApprovalAdminController {
     private final CourseService courseService;
     private final TrainingProgramService trainingProgramService;
     private final ContentModerationHistoryService contentModerationHistoryService;
+    private final CoursePendingEditService coursePendingEditService;
 
     @GetMapping("/courses/pending")
-    @Operation(summary = "List courses pending approval")
+    @Operation(
+            summary = "List courses pending first approval",
+            description = """
+                    Courses that have never been approved and are waiting on an initial decision.
+
+                    This does **not** include already-published courses with a pending edit: those
+                    keep `admin_approved = true` while their edit is reviewed, so they never match
+                    this query. Use `GET /api/v1/admin/courses/pending-edits` for those.
+                    """
+    )
     public ResponseEntity<ApiResponse<PagedDTO<CourseDTO>>> listPendingCourses(Pageable pageable) {
         Page<CourseDTO> pending = courseService.search(
                 Map.of("admin_approved", "false", "status_in", "IN_REVIEW,PUBLISHED"), pageable);
@@ -50,23 +69,103 @@ public class ContentApprovalAdminController {
         return ResponseEntity.ok(ApiResponse.success(PagedDTO.from(pending, baseUrl), "Pending courses retrieved successfully"));
     }
 
+    @GetMapping("/courses/pending-edits")
+    @Operation(
+            summary = "List edits to published courses awaiting review",
+            description = """
+                    Edits submitted against already-published courses, newest first.
+
+                    Each of these courses is still live and serving its last-approved content —
+                    the proposed change is held on a draft and is invisible to learners until
+                    approved. Approving promotes the draft onto the live course; rejecting
+                    discards it and leaves the live course exactly as it was.
+                    """,
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Pending edits retrieved successfully")
+            }
+    )
+    public ResponseEntity<ApiResponse<PagedDTO<CoursePendingEditDTO>>> listPendingCourseEdits(Pageable pageable) {
+        Page<CoursePendingEditDTO> pending = coursePendingEditService.getPendingQueue(pageable);
+        String baseUrl = ServletUriComponentsBuilder.fromCurrentRequestUri().build().toString();
+        return ResponseEntity.ok(ApiResponse.success(PagedDTO.from(pending, baseUrl),
+                "Pending course edits retrieved successfully"));
+    }
+
+    @GetMapping("/courses/{uuid}/pending-edit/diff")
+    @Operation(
+            summary = "Show what a pending edit would change",
+            description = """
+                    The difference between the live course and the edit awaiting review: which
+                    course fields change and how many lessons the edit adds, removes or modifies.
+                    """,
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Diff retrieved",
+                            content = @Content(schema = @Schema(implementation = CourseEditDiffDTO.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No edit awaiting review for this course")
+            }
+    )
+    public ResponseEntity<ApiResponse<CourseEditDiffDTO>> getCourseEditDiff(
+            @Parameter(description = "UUID of the live course") @PathVariable UUID uuid) {
+        return ResponseEntity.ok(ApiResponse.success(coursePendingEditService.diff(uuid),
+                "Course edit diff retrieved successfully"));
+    }
+
     @PostMapping("/courses/{uuid}/moderate")
-    @Operation(summary = "Moderate course approval")
-    public ResponseEntity<ApiResponse<CourseDTO>> moderateCourse(@PathVariable UUID uuid,
-                                                                 @RequestParam("action") String action,
-                                                                 @RequestParam(required = false) String reason) {
-        String normalizedAction = normalizeAction(action);
-        CourseDTO course = switch (normalizedAction) {
-            case "approve" -> courseService.approveCourse(uuid, reason);
-            case "reject" -> courseService.unapproveCourse(uuid, reason, ModerationAction.REJECTED);
-            case "revoke" -> courseService.unapproveCourse(uuid, reason, ModerationAction.REVOKED);
-            default -> throw unsupportedAction(action);
+    @Operation(
+            summary = "Moderate a course or its pending edit",
+            description = """
+                    Applies a moderation decision to a course.
+
+                    **When the course has an edit awaiting review**, the decision applies to that
+                    edit: `approved` promotes the draft onto the live course and records a new
+                    version; `rejected` discards the draft and leaves the live course untouched,
+                    including its approval — the published content was never at fault.
+
+                    **Otherwise** the decision applies to the course's own approval state, as
+                    before: `approved` makes it available, `rejected`/`revoked` withdraw it.
+
+                    Every decision is recorded in the course's moderation history with its reason.
+                    """,
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Decision applied successfully",
+                            content = @Content(schema = @Schema(implementation = CourseDTO.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Unsupported action"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Course not found")
+            }
+    )
+    public ResponseEntity<ApiResponse<CourseDTO>> moderateCourse(
+            @Parameter(description = "UUID of the course") @PathVariable UUID uuid,
+            @Valid @RequestBody ContentModerationDecisionRequest request) {
+
+        boolean hasPendingEdit = coursePendingEditService.findPending(uuid).isPresent();
+        ModerationAction action = request.action();
+        String reason = request.reason();
+
+        if (hasPendingEdit && action != ModerationAction.REVOKED) {
+            // The decision is about the proposed change, not the live course.
+            if (action == ModerationAction.APPROVED) {
+                coursePendingEditService.approve(uuid, reason);
+            } else {
+                coursePendingEditService.reject(uuid, reason);
+            }
+            contentModerationHistoryService.record(ModerationContentType.COURSE, uuid, action, reason);
+            CourseDTO course = courseService.getCourseByUuid(uuid);
+            String message = action == ModerationAction.APPROVED
+                    ? "Course edit approved and published successfully"
+                    : "Course edit rejected successfully; the live course is unchanged";
+            return ResponseEntity.ok(ApiResponse.success(course, message));
+        }
+
+        CourseDTO course = switch (action) {
+            case APPROVED -> courseService.approveCourse(uuid, reason);
+            case REJECTED -> courseService.unapproveCourse(uuid, reason, ModerationAction.REJECTED);
+            case REVOKED -> courseService.unapproveCourse(uuid, reason, ModerationAction.REVOKED);
         };
 
-        String message = switch (normalizedAction) {
-            case "approve" -> "Course approved successfully";
-            case "reject" -> "Course rejected successfully";
-            default -> "Course approval revoked successfully";
+        String message = switch (action) {
+            case APPROVED -> "Course approved successfully";
+            case REJECTED -> "Course rejected successfully";
+            case REVOKED -> "Course approval revoked successfully";
         };
         return ResponseEntity.ok(ApiResponse.success(course, message));
     }

--- a/src/main/java/apps/sarafrika/elimika/course/controller/admin/ContentApprovalAdminController.java
+++ b/src/main/java/apps/sarafrika/elimika/course/controller/admin/ContentApprovalAdminController.java
@@ -16,17 +16,13 @@ import apps.sarafrika.elimika.shared.dto.ApiResponse;
 import apps.sarafrika.elimika.shared.dto.PagedDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -34,9 +30,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.server.ResponseStatusException;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 @RestController
@@ -98,9 +92,10 @@ public class ContentApprovalAdminController {
                     The difference between the live course and the edit awaiting review: which
                     course fields change and how many lessons the edit adds, removes or modifies.
                     """,
+            // Response schemas are inferred from the return type so the generated clients see
+            // the real ApiResponse envelope rather than the bare payload.
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Diff retrieved",
-                            content = @Content(schema = @Schema(implementation = CourseEditDiffDTO.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Diff retrieved"),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "No edit awaiting review for this course")
             }
     )
@@ -127,8 +122,7 @@ public class ContentApprovalAdminController {
                     Every decision is recorded in the course's moderation history with its reason.
                     """,
             responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Decision applied successfully",
-                            content = @Content(schema = @Schema(implementation = CourseDTO.class))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Decision applied successfully"),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "Unsupported action"),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "Course not found")
             }
@@ -200,21 +194,23 @@ public class ContentApprovalAdminController {
 
     @PostMapping("/programs/{uuid}/moderate")
     @Operation(summary = "Moderate training program approval")
-    public ResponseEntity<ApiResponse<TrainingProgramDTO>> moderateProgram(@PathVariable UUID uuid,
-                                                                           @RequestParam("action") String action,
-                                                                           @RequestParam(required = false) String reason) {
-        String normalizedAction = normalizeAction(action);
-        TrainingProgramDTO program = switch (normalizedAction) {
-            case "approve" -> trainingProgramService.approveProgram(uuid, reason);
-            case "reject" -> trainingProgramService.unapproveProgram(uuid, reason, ModerationAction.REJECTED);
-            case "revoke" -> trainingProgramService.unapproveProgram(uuid, reason, ModerationAction.REVOKED);
-            default -> throw unsupportedAction(action);
+    public ResponseEntity<ApiResponse<TrainingProgramDTO>> moderateProgram(
+            @Parameter(description = "UUID of the training program") @PathVariable UUID uuid,
+            @Valid @RequestBody ContentModerationDecisionRequest request) {
+
+        ModerationAction action = request.action();
+        String reason = request.reason();
+
+        TrainingProgramDTO program = switch (action) {
+            case APPROVED -> trainingProgramService.approveProgram(uuid, reason);
+            case REJECTED -> trainingProgramService.unapproveProgram(uuid, reason, ModerationAction.REJECTED);
+            case REVOKED -> trainingProgramService.unapproveProgram(uuid, reason, ModerationAction.REVOKED);
         };
 
-        String message = switch (normalizedAction) {
-            case "approve" -> "Training program approved successfully";
-            case "reject" -> "Training program rejected successfully";
-            default -> "Training program approval revoked successfully";
+        String message = switch (action) {
+            case APPROVED -> "Training program approved successfully";
+            case REJECTED -> "Training program rejected successfully";
+            case REVOKED -> "Training program approval revoked successfully";
         };
         return ResponseEntity.ok(ApiResponse.success(program, message));
     }
@@ -238,17 +234,4 @@ public class ContentApprovalAdminController {
                 "Training program moderation history retrieved successfully"));
     }
 
-    private String normalizeAction(String action) {
-        if (action == null) {
-            return "";
-        }
-        return action.trim().toLowerCase(Locale.ROOT);
-    }
-
-    private ResponseStatusException unsupportedAction(String action) {
-        return new ResponseStatusException(
-                HttpStatus.BAD_REQUEST,
-                "Unsupported moderation action: " + action + ". Allowed values: approve, reject, revoke"
-        );
-    }
 }

--- a/src/main/java/apps/sarafrika/elimika/course/dto/ContentModerationDecisionRequest.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/ContentModerationDecisionRequest.java
@@ -1,0 +1,53 @@
+package apps.sarafrika.elimika.course.dto;
+
+import apps.sarafrika.elimika.course.util.enums.ModerationAction;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request payload used by platform admins when moderating a course or training program.
+ * <p>
+ * Replaces the previous free-form {@code ?action=} query parameter so the allowed values are
+ * expressed in the schema rather than validated by hand in the controller.
+ */
+@Schema(
+        name = "ContentModerationDecisionRequest",
+        description = """
+                Payload for a moderation decision on a course or training program.
+
+                When the content has a pending edit awaiting review, `approved` promotes that
+                edit onto the live content and `rejected` discards it, leaving the live content
+                untouched. Otherwise the decision applies to the content's own approval state.
+                """,
+        example = """
+        {
+          "action": "rejected",
+          "reason": "Lesson 3 video is missing captions."
+        }
+        """
+)
+public record ContentModerationDecisionRequest(
+
+        @Schema(
+                description = "The decision to apply.",
+                allowableValues = {"approved", "rejected", "revoked"},
+                requiredMode = Schema.RequiredMode.REQUIRED
+        )
+        @JsonProperty("action")
+        @NotNull(message = "Moderation action is required")
+        ModerationAction action,
+
+        @Schema(
+                description = "Reason for the decision. Shown to the course creator and retained in the moderation history.",
+                maxLength = 2000,
+                nullable = true
+        )
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        @JsonProperty("reason")
+        @Size(max = 2000, message = "Reason must not exceed 2000 characters")
+        String reason
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/course/dto/CourseEditDiffDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/CourseEditDiffDTO.java
@@ -1,0 +1,71 @@
+package apps.sarafrika.elimika.course.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(
+        name = "CourseEditDiff",
+        description = """
+                What a pending edit would change if approved, so an admin can review the
+                decision without comparing two full course payloads by eye.
+                """,
+        example = """
+        {
+          "course_uuid": "course-1234-5678-90ab-cdef12345678",
+          "draft_course_uuid": "draft-1234-5678-90ab-cdef12345678",
+          "field_changes": [
+            { "field": "name", "live_value": "Intro to Piano", "draft_value": "Introduction to Piano" },
+            { "field": "price", "live_value": "1500.00", "draft_value": "1800.00" }
+          ],
+          "lessons_added": 1,
+          "lessons_removed": 0,
+          "lessons_modified": 2
+        }
+        """
+)
+public record CourseEditDiffDTO(
+
+        @Schema(description = "**[READ-ONLY]** The live course under review.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "course_uuid", access = JsonProperty.Access.READ_ONLY)
+        java.util.UUID courseUuid,
+
+        @Schema(description = "**[READ-ONLY]** Draft course holding the proposed content.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "draft_course_uuid", access = JsonProperty.Access.READ_ONLY)
+        java.util.UUID draftCourseUuid,
+
+        @Schema(description = "**[READ-ONLY]** Course fields that differ between the live course and the draft.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "field_changes", access = JsonProperty.Access.READ_ONLY)
+        List<FieldChange> fieldChanges,
+
+        @Schema(description = "**[READ-ONLY]** Lessons the edit adds.", example = "1", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "lessons_added", access = JsonProperty.Access.READ_ONLY)
+        int lessonsAdded,
+
+        @Schema(description = "**[READ-ONLY]** Lessons the edit removes.", example = "0", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "lessons_removed", access = JsonProperty.Access.READ_ONLY)
+        int lessonsRemoved,
+
+        @Schema(description = "**[READ-ONLY]** Lessons the edit changes in place.", example = "2", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "lessons_modified", access = JsonProperty.Access.READ_ONLY)
+        int lessonsModified
+) {
+
+    @Schema(name = "CourseEditFieldChange", description = "A single course field the edit would change.")
+    public record FieldChange(
+
+            @Schema(description = "**[READ-ONLY]** Field name, in snake_case as it appears on the course payload.", example = "price")
+            @JsonProperty(value = "field", access = JsonProperty.Access.READ_ONLY)
+            String field,
+
+            @Schema(description = "**[READ-ONLY]** Current value on the live course, rendered as text.", example = "1500.00")
+            @JsonProperty(value = "live_value", access = JsonProperty.Access.READ_ONLY)
+            String liveValue,
+
+            @Schema(description = "**[READ-ONLY]** Proposed value on the draft, rendered as text.", example = "1800.00")
+            @JsonProperty(value = "draft_value", access = JsonProperty.Access.READ_ONLY)
+            String draftValue
+    ) {
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/course/dto/CoursePendingEditDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/CoursePendingEditDTO.java
@@ -1,0 +1,110 @@
+package apps.sarafrika.elimika.course.dto;
+
+import apps.sarafrika.elimika.course.util.enums.PendingEditStatus;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(
+        name = "CoursePendingEdit",
+        description = """
+                An edit to a published course that is awaiting admin review.
+
+                The live course is unaffected while the edit is pending: it stays published,
+                keeps accepting enrollments, and continues to serve its last-approved content.
+                The proposed content lives on the draft course referenced by `draft_course_uuid`.
+                """,
+        example = """
+        {
+          "uuid": "edit-1234-5678-90ab-cdef12345678",
+          "course_uuid": "course-1234-5678-90ab-cdef12345678",
+          "draft_course_uuid": "draft-1234-5678-90ab-cdef12345678",
+          "status": "pending",
+          "submitted_by_uuid": "user-1234-5678-90ab-cdef12345678",
+          "submitted_at": "2026-07-17T09:00:00",
+          "reviewed_by_uuid": null,
+          "reviewed_at": null,
+          "review_reason": null
+        }
+        """
+)
+public record CoursePendingEditDTO(
+
+        @Schema(
+                description = "**[READ-ONLY]** Unique identifier for the pending edit.",
+                example = "edit-1234-5678-90ab-cdef12345678",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID uuid,
+
+        @Schema(
+                description = "**[READ-ONLY]** The live course this edit applies to.",
+                example = "course-1234-5678-90ab-cdef12345678",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "course_uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID courseUuid,
+
+        @Schema(
+                description = "**[READ-ONLY]** Draft course holding the proposed content. Null once the edit is resolved.",
+                example = "draft-1234-5678-90ab-cdef12345678",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "draft_course_uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID draftCourseUuid,
+
+        @Schema(
+                description = "**[READ-ONLY]** Review state of the edit.",
+                example = "pending",
+                allowableValues = {"pending", "approved", "rejected", "withdrawn"},
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "status", access = JsonProperty.Access.READ_ONLY)
+        PendingEditStatus status,
+
+        @Schema(
+                description = "**[READ-ONLY]** Internal user UUID of the course creator who submitted the edit.",
+                example = "user-1234-5678-90ab-cdef12345678",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "submitted_by_uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID submittedByUuid,
+
+        @Schema(
+                description = "**[READ-ONLY]** When the edit was submitted for review.",
+                example = "2026-07-17T09:00:00",
+                format = "date-time",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "submitted_at", access = JsonProperty.Access.READ_ONLY)
+        LocalDateTime submittedAt,
+
+        @Schema(
+                description = "**[READ-ONLY]** Internal user UUID of the admin who reviewed the edit.",
+                example = "user-9999-5678-90ab-cdef12345678",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "reviewed_by_uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID reviewedByUuid,
+
+        @Schema(
+                description = "**[READ-ONLY]** When the edit was reviewed.",
+                example = "2026-07-17T11:30:00",
+                format = "date-time",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "reviewed_at", access = JsonProperty.Access.READ_ONLY)
+        LocalDateTime reviewedAt,
+
+        @Schema(
+                description = "**[READ-ONLY]** Reason the admin gave for their decision.",
+                example = "Pricing change is not justified.",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "review_reason", access = JsonProperty.Access.READ_ONLY)
+        String reviewReason
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/course/dto/CourseVersionSnapshotDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/CourseVersionSnapshotDTO.java
@@ -1,0 +1,61 @@
+package apps.sarafrika.elimika.course.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(
+        name = "CourseVersionSnapshot",
+        description = """
+                An approved version of a course's content. One is written each time an edit is
+                promoted onto the live course, giving a durable record of what the course
+                looked like at each approved version.
+                """,
+        example = """
+        {
+          "uuid": "snap-1234-5678-90ab-cdef12345678",
+          "course_uuid": "course-1234-5678-90ab-cdef12345678",
+          "version_number": 3,
+          "pending_edit_uuid": "edit-1234-5678-90ab-cdef12345678",
+          "created_date": "2026-07-17T11:30:00",
+          "created_by": "admin@example.com"
+        }
+        """
+)
+public record CourseVersionSnapshotDTO(
+
+        @Schema(description = "**[READ-ONLY]** Unique identifier for the snapshot.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID uuid,
+
+        @Schema(description = "**[READ-ONLY]** The course this version belongs to.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "course_uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID courseUuid,
+
+        @Schema(description = "**[READ-ONLY]** Monotonic version number, starting at 1.", example = "3", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "version_number", access = JsonProperty.Access.READ_ONLY)
+        Integer versionNumber,
+
+        @Schema(
+                description = "**[READ-ONLY]** Full course tree at this version: course fields, category uuids, lessons and their content.",
+                accessMode = Schema.AccessMode.READ_ONLY
+        )
+        @JsonProperty(value = "snapshot", access = JsonProperty.Access.READ_ONLY)
+        JsonNode snapshot,
+
+        @Schema(description = "**[READ-ONLY]** The edit whose promotion produced this version, if any.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "pending_edit_uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID pendingEditUuid,
+
+        @Schema(description = "**[READ-ONLY]** When this version became live.", format = "date-time", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "created_date", access = JsonProperty.Access.READ_ONLY)
+        LocalDateTime createdDate,
+
+        @Schema(description = "**[READ-ONLY]** Who promoted this version.", example = "admin@example.com", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "created_by", access = JsonProperty.Access.READ_ONLY)
+        String createdBy
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/course/dto/LessonContentDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/LessonContentDTO.java
@@ -195,6 +195,33 @@ public record LessonContentDTO(
 ) {
 
     /**
+     * A copy of this content bound to the given lesson.
+     * <p>
+     * Lets a caller pin the content to the lesson it was addressed under, rather than trusting
+     * the {@code lesson_uuid} in the request body, and lets an authoring write be redirected
+     * onto a course's draft while an edit is awaiting review.
+     */
+    public LessonContentDTO withLessonUuid(UUID targetLessonUuid) {
+        return new LessonContentDTO(
+                uuid,
+                targetLessonUuid,
+                contentTypeUuid,
+                title,
+                description,
+                contentText,
+                fileUrl,
+                fileSizeBytes,
+                mimeType,
+                displayOrder,
+                isRequired,
+                createdDate,
+                createdBy,
+                updatedDate,
+                updatedBy
+        );
+    }
+
+    /**
      * Returns a formatted display string for file size.
      *
      * @return Formatted file size or "No file" if not applicable

--- a/src/main/java/apps/sarafrika/elimika/course/dto/LessonDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/LessonDTO.java
@@ -160,6 +160,30 @@ public record LessonDTO(
 
 ) {
     /**
+     * A copy of this lesson bound to the given course.
+     * <p>
+     * Lets a caller pin the lesson to the course it was addressed under, rather than trusting
+     * the {@code course_uuid} in the request body, and lets an authoring write be redirected
+     * onto a course's draft while an edit is awaiting review.
+     */
+    public LessonDTO withCourseUuid(UUID targetCourseUuid) {
+        return new LessonDTO(
+                uuid,
+                targetCourseUuid,
+                lessonNumber,
+                title,
+                description,
+                learningObjectives,
+                status,
+                active,
+                createdDate,
+                createdBy,
+                updatedDate,
+                updatedBy
+        );
+    }
+
+    /**
      * Checks if the lesson is published and available to students.
      *
      * @return true if status is PUBLISHED

--- a/src/main/java/apps/sarafrika/elimika/course/factory/CoursePendingEditFactory.java
+++ b/src/main/java/apps/sarafrika/elimika/course/factory/CoursePendingEditFactory.java
@@ -1,0 +1,27 @@
+package apps.sarafrika.elimika.course.factory;
+
+import apps.sarafrika.elimika.course.dto.CoursePendingEditDTO;
+import apps.sarafrika.elimika.course.model.CoursePendingEdit;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CoursePendingEditFactory {
+
+    public static CoursePendingEditDTO toDTO(CoursePendingEdit entity) {
+        if (entity == null) {
+            return null;
+        }
+        return new CoursePendingEditDTO(
+                entity.getUuid(),
+                entity.getCourseUuid(),
+                entity.getDraftCourseUuid(),
+                entity.getStatus(),
+                entity.getSubmittedByUuid(),
+                entity.getSubmittedAt(),
+                entity.getReviewedByUuid(),
+                entity.getReviewedAt(),
+                entity.getReviewReason()
+        );
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/course/factory/CourseVersionSnapshotFactory.java
+++ b/src/main/java/apps/sarafrika/elimika/course/factory/CourseVersionSnapshotFactory.java
@@ -1,0 +1,25 @@
+package apps.sarafrika.elimika.course.factory;
+
+import apps.sarafrika.elimika.course.dto.CourseVersionSnapshotDTO;
+import apps.sarafrika.elimika.course.model.CourseVersionSnapshot;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CourseVersionSnapshotFactory {
+
+    public static CourseVersionSnapshotDTO toDTO(CourseVersionSnapshot entity) {
+        if (entity == null) {
+            return null;
+        }
+        return new CourseVersionSnapshotDTO(
+                entity.getUuid(),
+                entity.getCourseUuid(),
+                entity.getVersionNumber(),
+                entity.getSnapshot(),
+                entity.getPendingEditUuid(),
+                entity.getCreatedDate(),
+                entity.getCreatedBy()
+        );
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/course/model/Course.java
+++ b/src/main/java/apps/sarafrika/elimika/course/model/Course.java
@@ -89,6 +89,14 @@ public class Course extends BaseEntity {
     @Column(name = "admin_approved")
     private Boolean adminApproved;
 
+    /**
+     * Set only on a shadow draft row holding an unapproved edit of the referenced live
+     * course. NULL on real courses. A draft is DRAFT/inactive/unapproved, so the existing
+     * catalogue filters already exclude it.
+     */
+    @Column(name = "parent_course_uuid")
+    private UUID parentCourseUuid;
+
     // Many-to-many relationship with categories through junction table
     @OneToMany(mappedBy = "course", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Set<CourseCategoryMapping> categoryMappings = new HashSet<>();

--- a/src/main/java/apps/sarafrika/elimika/course/model/CourseAssessment.java
+++ b/src/main/java/apps/sarafrika/elimika/course/model/CourseAssessment.java
@@ -50,4 +50,14 @@ public class CourseAssessment extends BaseEntity {
 
     @Column(name = "is_required")
     private Boolean isRequired;
+
+    @Column(name = "active")
+    private Boolean active;
+
+    /**
+     * On a draft assessment, the live assessment it will be promoted onto. NULL means the
+     * edit adds it. Preserves live assessment uuids so assessment scores stay valid.
+     */
+    @Column(name = "source_assessment_uuid")
+    private UUID sourceAssessmentUuid;
 }

--- a/src/main/java/apps/sarafrika/elimika/course/model/CourseAssessmentLineItem.java
+++ b/src/main/java/apps/sarafrika/elimika/course/model/CourseAssessmentLineItem.java
@@ -63,4 +63,11 @@ public class CourseAssessmentLineItem extends BaseEntity {
 
     @Column(name = "due_at")
     private LocalDateTime dueAt;
+
+    /**
+     * On a draft line item, the live line item it will be promoted onto. NULL means the edit
+     * adds it. Preserves live uuids so line-item scores and rubric evaluations stay valid.
+     */
+    @Column(name = "source_line_item_uuid")
+    private UUID sourceLineItemUuid;
 }

--- a/src/main/java/apps/sarafrika/elimika/course/model/CoursePendingEdit.java
+++ b/src/main/java/apps/sarafrika/elimika/course/model/CoursePendingEdit.java
@@ -1,0 +1,57 @@
+package apps.sarafrika.elimika.course.model;
+
+import apps.sarafrika.elimika.course.util.converter.PendingEditStatusConverter;
+import apps.sarafrika.elimika.course.util.enums.PendingEditStatus;
+import apps.sarafrika.elimika.shared.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Review state for a course edit held on a shadow draft course.
+ * <p>
+ * The proposed content lives on the draft course referenced by {@code draftCourseUuid};
+ * this row only tracks who submitted it, who reviewed it and how it was resolved. Resolved
+ * rows are retained, so the table doubles as the edit-submission history for a course.
+ */
+@Entity
+@Table(name = "course_pending_edits")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CoursePendingEdit extends BaseEntity {
+
+    @Column(name = "course_uuid")
+    private UUID courseUuid;
+
+    @Column(name = "draft_course_uuid")
+    private UUID draftCourseUuid;
+
+    @Column(name = "status")
+    @Convert(converter = PendingEditStatusConverter.class)
+    private PendingEditStatus status;
+
+    @Column(name = "submitted_by_uuid")
+    private UUID submittedByUuid;
+
+    @Column(name = "submitted_at")
+    private LocalDateTime submittedAt;
+
+    @Column(name = "reviewed_by_uuid")
+    private UUID reviewedByUuid;
+
+    @Column(name = "reviewed_at")
+    private LocalDateTime reviewedAt;
+
+    @Column(name = "review_reason")
+    private String reviewReason;
+}

--- a/src/main/java/apps/sarafrika/elimika/course/model/CourseRequirement.java
+++ b/src/main/java/apps/sarafrika/elimika/course/model/CourseRequirement.java
@@ -34,4 +34,11 @@ public class CourseRequirement extends BaseEntity {
 
     @Column(name = "is_mandatory")
     private Boolean isMandatory;
+
+    /**
+     * On a draft requirement, the live requirement it will be promoted onto. NULL means the
+     * edit adds it. Used to route edits of a live requirement to its draft copy.
+     */
+    @Column(name = "source_requirement_uuid")
+    private UUID sourceRequirementUuid;
 }

--- a/src/main/java/apps/sarafrika/elimika/course/model/CourseTrainingRequirement.java
+++ b/src/main/java/apps/sarafrika/elimika/course/model/CourseTrainingRequirement.java
@@ -49,4 +49,11 @@ public class CourseTrainingRequirement extends BaseEntity {
 
     @Column(name = "is_mandatory", nullable = false)
     private Boolean isMandatory = true;
+
+    /**
+     * On a draft training requirement, the live one it will be promoted onto. NULL means the
+     * edit adds it. Used to route edits of a live requirement to its draft copy.
+     */
+    @Column(name = "source_requirement_uuid")
+    private UUID sourceRequirementUuid;
 }

--- a/src/main/java/apps/sarafrika/elimika/course/model/CourseVersionSnapshot.java
+++ b/src/main/java/apps/sarafrika/elimika/course/model/CourseVersionSnapshot.java
@@ -1,0 +1,48 @@
+package apps.sarafrika.elimika.course.model;
+
+import apps.sarafrika.elimika.shared.model.BaseEntity;
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+import java.util.UUID;
+
+/**
+ * An approved version of a course's content.
+ * <p>
+ * {@link ContentModerationHistory} records moderation decisions but no content; this records
+ * the content itself. A row is written each time an edit is promoted onto the live course,
+ * giving a durable history of what the course looked like at each approved version.
+ */
+@Entity
+@Table(name = "course_version_snapshots")
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CourseVersionSnapshot extends BaseEntity {
+
+    @Column(name = "course_uuid")
+    private UUID courseUuid;
+
+    @Column(name = "version_number")
+    private Integer versionNumber;
+
+    /**
+     * Full course tree: course fields, category uuids, lessons and their content. Media
+     * fields hold storage keys rather than resolved URLs.
+     */
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "snapshot")
+    private JsonNode snapshot;
+
+    @Column(name = "pending_edit_uuid")
+    private UUID pendingEditUuid;
+}

--- a/src/main/java/apps/sarafrika/elimika/course/model/Lesson.java
+++ b/src/main/java/apps/sarafrika/elimika/course/model/Lesson.java
@@ -44,4 +44,12 @@ public class Lesson extends BaseEntity {
 
     @Column(name = "active")
     private Boolean active;
+
+    /**
+     * On a draft lesson, the live lesson this one will be promoted onto. NULL means the
+     * edit adds this lesson. Promotion updates matched live lessons in place so their
+     * uuids survive and learner progress rows stay valid.
+     */
+    @Column(name = "source_lesson_uuid")
+    private UUID sourceLessonUuid;
 }

--- a/src/main/java/apps/sarafrika/elimika/course/model/LessonContent.java
+++ b/src/main/java/apps/sarafrika/elimika/course/model/LessonContent.java
@@ -42,4 +42,11 @@ public class LessonContent extends BaseEntity {
 
     @Column(name = "is_required")
     private Boolean isRequired;
+
+    /**
+     * On draft content, the live content it will be promoted onto. NULL means the edit adds
+     * it. Preserves live content uuids so content_progress stays valid.
+     */
+    @Column(name = "source_content_uuid")
+    private UUID sourceContentUuid;
 }

--- a/src/main/java/apps/sarafrika/elimika/course/model/QuizQuestion.java
+++ b/src/main/java/apps/sarafrika/elimika/course/model/QuizQuestion.java
@@ -33,4 +33,11 @@ public class QuizQuestion extends BaseEntity {
 
     @Column(name = "display_order")
     private Integer displayOrder;
+
+    /**
+     * On a draft question, the live question it will be promoted onto. NULL means the edit
+     * adds it. Preserves live question uuids so quiz_responses stay valid.
+     */
+    @Column(name = "source_question_uuid")
+    private UUID sourceQuestionUuid;
 }

--- a/src/main/java/apps/sarafrika/elimika/course/model/QuizQuestionOption.java
+++ b/src/main/java/apps/sarafrika/elimika/course/model/QuizQuestionOption.java
@@ -24,4 +24,11 @@ public class QuizQuestionOption extends BaseEntity {
 
     @Column(name = "display_order")
     private Integer displayOrder;
+
+    /**
+     * On a draft option, the live option it will be promoted onto. NULL means the edit adds
+     * it. Preserves live option uuids so quiz_responses.selected_option_uuid stays valid.
+     */
+    @Column(name = "source_option_uuid")
+    private UUID sourceOptionUuid;
 }

--- a/src/main/java/apps/sarafrika/elimika/course/repository/AssignmentRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/course/repository/AssignmentRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -16,4 +17,6 @@ public interface AssignmentRepository extends JpaRepository<Assignment, Long>,
     void deleteByUuid(UUID uuid);
 
     boolean existsByUuid(UUID uuid);
+
+    List<Assignment> findByLessonUuid(UUID lessonUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/course/repository/CoursePendingEditRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/course/repository/CoursePendingEditRepository.java
@@ -1,0 +1,32 @@
+package apps.sarafrika.elimika.course.repository;
+
+import apps.sarafrika.elimika.course.model.CoursePendingEdit;
+import apps.sarafrika.elimika.course.util.enums.PendingEditStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface CoursePendingEditRepository extends JpaRepository<CoursePendingEdit, Long> {
+
+    /**
+     * The open edit for a course, if any. At most one can exist — enforced by the partial
+     * unique index uq_cpe_one_pending_per_course.
+     */
+    Optional<CoursePendingEdit> findByCourseUuidAndStatus(UUID courseUuid, PendingEditStatus status);
+
+    Optional<CoursePendingEdit> findByUuid(UUID uuid);
+
+    Optional<CoursePendingEdit> findByDraftCourseUuid(UUID draftCourseUuid);
+
+    /** Drives the admin review queue. */
+    Page<CoursePendingEdit> findByStatusOrderBySubmittedAtDesc(PendingEditStatus status, Pageable pageable);
+
+    Page<CoursePendingEdit> findByCourseUuidOrderBySubmittedAtDesc(UUID courseUuid, Pageable pageable);
+
+    boolean existsByCourseUuidAndStatus(UUID courseUuid, PendingEditStatus status);
+}

--- a/src/main/java/apps/sarafrika/elimika/course/repository/CourseRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/course/repository/CourseRepository.java
@@ -28,6 +28,9 @@ public interface CourseRepository extends JpaRepository<Course, Long>, JpaSpecif
 
     List<Course> findByUuidIn(List<UUID> uuids);
 
+    /** The open draft holding an unapproved edit of the given live course, if any. */
+    Optional<Course> findByParentCourseUuid(UUID parentCourseUuid);
+
     @Query("select c.uuid from Course c where c.courseCreatorUuid = :courseCreatorUuid")
     List<UUID> findUuidsByCourseCreatorUuid(@Param("courseCreatorUuid") UUID courseCreatorUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/course/repository/CourseRequirementRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/course/repository/CourseRequirementRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -15,4 +16,6 @@ public interface CourseRequirementRepository extends JpaRepository<CourseRequire
     void deleteByUuid(UUID uuid);
 
     boolean existsByUuid(UUID uuid);
+
+    List<CourseRequirement> findByCourseUuid(UUID courseUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/course/repository/CourseVersionSnapshotRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/course/repository/CourseVersionSnapshotRepository.java
@@ -1,0 +1,21 @@
+package apps.sarafrika.elimika.course.repository;
+
+import apps.sarafrika.elimika.course.model.CourseVersionSnapshot;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface CourseVersionSnapshotRepository extends JpaRepository<CourseVersionSnapshot, Long> {
+
+    Page<CourseVersionSnapshot> findByCourseUuidOrderByVersionNumberDesc(UUID courseUuid, Pageable pageable);
+
+    /** Source of the next version number for a course. */
+    Optional<CourseVersionSnapshot> findTopByCourseUuidOrderByVersionNumberDesc(UUID courseUuid);
+
+    Optional<CourseVersionSnapshot> findByUuid(UUID uuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/course/repository/LessonRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/course/repository/LessonRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -15,4 +16,6 @@ public interface LessonRepository extends JpaRepository<Lesson, Long>, JpaSpecif
     void deleteByUuid(UUID uuid);
 
     boolean existsByUuid(UUID uuid);
+
+    List<Lesson> findByCourseUuidOrderByLessonNumberAsc(UUID courseUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/course/repository/QuizRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/course/repository/QuizRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -15,4 +16,6 @@ public interface QuizRepository extends JpaRepository<Quiz, Long>, JpaSpecificat
     void deleteByUuid(UUID uuid);
 
     boolean existsByUuid(UUID uuid);
+
+    List<Quiz> findByLessonUuid(UUID lessonUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/course/service/CourseDraftService.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/CourseDraftService.java
@@ -1,0 +1,101 @@
+package apps.sarafrika.elimika.course.service;
+
+import apps.sarafrika.elimika.course.dto.CourseEditDiffDTO;
+import apps.sarafrika.elimika.course.model.Course;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Draft-over-live editing for published courses.
+ * <p>
+ * An edit to a published, admin-approved course is held on a shadow "draft" course row
+ * rather than applied to the live row, so the live course keeps serving its last-approved
+ * content while the edit awaits review. Approving promotes the draft onto the live course;
+ * rejecting simply discards the draft, which is why a rejected edit needs no rollback —
+ * the live course was never touched.
+ *
+ * @see CoursePendingEditService for the review state around a draft
+ */
+public interface CourseDraftService {
+
+    /**
+     * The open draft for a live course, creating one by cloning the live course tree if
+     * none exists. Idempotent: repeated calls return the same draft, so a creator making
+     * several edits keeps building on one working copy.
+     *
+     * @param liveCourseUuid the published course being edited
+     * @return the draft course row
+     */
+    Course openDraft(UUID liveCourseUuid);
+
+    /**
+     * The open draft for a live course, if one exists.
+     */
+    Optional<Course> findDraft(UUID liveCourseUuid);
+
+    /**
+     * Applies the draft's content onto the live course and deletes the draft.
+     * <p>
+     * The live course row and its lesson uuids are preserved — lessons are matched by
+     * {@code sourceLessonUuid} and updated in place — so enrollments, catalogue entries and
+     * learner progress stay intact. Writes a {@code CourseVersionSnapshot} of the resulting
+     * live tree.
+     *
+     * @param liveCourseUuid the published course receiving the edit
+     * @param pendingEditUuid the edit being promoted, recorded on the snapshot
+     */
+    void promote(UUID liveCourseUuid, UUID pendingEditUuid);
+
+    /**
+     * Deletes the open draft for a course. The live course is not modified.
+     */
+    void discard(UUID liveCourseUuid);
+
+    /**
+     * Serializes a course's full tree — course fields, category uuids, lessons and their
+     * content — for the version history. Media fields hold storage keys, not resolved URLs.
+     */
+    JsonNode snapshotTree(UUID courseUuid);
+
+    /**
+     * What the open draft would change about the live course if approved.
+     */
+    CourseEditDiffDTO diff(UUID liveCourseUuid);
+
+    /**
+     * The course a creator's authoring write should actually land on.
+     * <p>
+     * For a live, approved course this is its draft — opened on demand — so lesson and content
+     * edits are reviewed like any other material change. For anything else it is the course
+     * itself. Lets the existing lesson endpoints stay unchanged: they simply operate on the
+     * uuid this returns.
+     */
+    UUID resolveEditableCourseUuid(UUID courseUuid);
+
+    /**
+     * The lesson a creator's authoring write should actually land on, given the lesson they
+     * named and the course they named it under.
+     * <p>
+     * Also closes an authorization gap: the lesson endpoints authorize on the path course but
+     * previously acted on the lesson uuid alone, so a creator could edit a lesson belonging to
+     * someone else's course by naming their own course in the path. This verifies the lesson
+     * really belongs to that course before returning anything.
+     *
+     * @throws apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException if the lesson
+     *         does not belong to the course (or its draft)
+     */
+    UUID resolveEditableLessonUuid(UUID courseUuid, UUID lessonUuid);
+
+    /**
+     * The lesson content a creator's authoring write should land on, given the course, lesson
+     * and content they named. Same purpose as {@link #resolveEditableLessonUuid}: verifies the
+     * content really hangs off that lesson under that course, and redirects to the draft's copy
+     * while an edit is awaiting review.
+     *
+     * @throws apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException if the content
+     *         does not belong to the lesson, or the lesson to the course
+     */
+    UUID resolveEditableContentUuid(UUID courseUuid, UUID lessonUuid, UUID contentUuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/course/service/CourseDraftService.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/CourseDraftService.java
@@ -98,4 +98,22 @@ public interface CourseDraftService {
      *         does not belong to the lesson, or the lesson to the course
      */
     UUID resolveEditableContentUuid(UUID courseUuid, UUID lessonUuid, UUID contentUuid);
+
+    /**
+     * The assessment a creator's authoring write should land on, redirecting to the draft's
+     * copy while an edit is awaiting review and verifying the assessment belongs to the course.
+     */
+    UUID resolveEditableAssessmentUuid(UUID courseUuid, UUID assessmentUuid);
+
+    /**
+     * The course requirement a creator's authoring write should land on, redirecting to the
+     * draft's copy while an edit is awaiting review.
+     */
+    UUID resolveEditableRequirementUuid(UUID courseUuid, UUID requirementUuid);
+
+    /**
+     * The training requirement a creator's authoring write should land on, redirecting to the
+     * draft's copy while an edit is awaiting review.
+     */
+    UUID resolveEditableTrainingRequirementUuid(UUID courseUuid, UUID requirementUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/course/service/CoursePendingEditService.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/CoursePendingEditService.java
@@ -1,0 +1,59 @@
+package apps.sarafrika.elimika.course.service;
+
+import apps.sarafrika.elimika.course.dto.CoursePendingEditDTO;
+import apps.sarafrika.elimika.course.dto.CourseEditDiffDTO;
+import apps.sarafrika.elimika.course.dto.CourseVersionSnapshotDTO;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Review workflow around a draft-over-live course edit.
+ * <p>
+ * Pairs with {@link CourseDraftService}, which owns the draft content itself: this service
+ * owns who submitted an edit, who reviewed it, and how it was resolved.
+ */
+public interface CoursePendingEditService {
+
+    /**
+     * Records that the course has an edit awaiting review, or refreshes the existing one if
+     * the creator is still working on it. Idempotent per course — at most one edit can be
+     * pending, which the database enforces.
+     */
+    CoursePendingEditDTO submitOrRefresh(UUID courseUuid, UUID draftCourseUuid);
+
+    Optional<CoursePendingEditDTO> findPending(UUID courseUuid);
+
+    /** Every edit ever submitted for a course, newest first. */
+    Page<CoursePendingEditDTO> getHistory(UUID courseUuid, Pageable pageable);
+
+    /** The admin review queue: every course with an edit awaiting a decision. */
+    Page<CoursePendingEditDTO> getPendingQueue(Pageable pageable);
+
+    /**
+     * Promotes the pending edit onto the live course and marks it approved.
+     *
+     * @throws apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException if no edit is pending
+     */
+    CoursePendingEditDTO approve(UUID courseUuid, String reason);
+
+    /**
+     * Discards the pending edit and marks it rejected. The live course is not modified and
+     * keeps its approval — the published content was never at fault.
+     */
+    CoursePendingEditDTO reject(UUID courseUuid, String reason);
+
+    /** The creator abandons their own pending edit. */
+    CoursePendingEditDTO withdraw(UUID courseUuid);
+
+    /** What the pending edit would change if approved. */
+    CourseEditDiffDTO diff(UUID courseUuid);
+
+    /** Approved content history for a course. */
+    Page<CourseVersionSnapshotDTO> getVersions(UUID courseUuid, Pageable pageable);
+
+    /** Whether an edit to this course must go through review rather than apply live. */
+    boolean requiresReview(UUID courseUuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/course/service/impl/CourseDraftServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/impl/CourseDraftServiceImpl.java
@@ -1,0 +1,846 @@
+package apps.sarafrika.elimika.course.service.impl;
+
+import apps.sarafrika.elimika.course.dto.CourseEditDiffDTO;
+import apps.sarafrika.elimika.course.model.Assignment;
+import apps.sarafrika.elimika.course.model.AssignmentAttachment;
+import apps.sarafrika.elimika.course.model.Course;
+import apps.sarafrika.elimika.course.model.CourseCategoryMapping;
+import apps.sarafrika.elimika.course.model.CourseVersionSnapshot;
+import apps.sarafrika.elimika.course.model.Lesson;
+import apps.sarafrika.elimika.course.model.LessonContent;
+import apps.sarafrika.elimika.course.model.LessonPracticeActivity;
+import apps.sarafrika.elimika.course.model.Quiz;
+import apps.sarafrika.elimika.course.model.QuizQuestion;
+import apps.sarafrika.elimika.course.model.QuizQuestionOption;
+import apps.sarafrika.elimika.course.repository.AssignmentAttachmentRepository;
+import apps.sarafrika.elimika.course.repository.AssignmentRepository;
+import apps.sarafrika.elimika.course.repository.CourseCategoryMappingRepository;
+import apps.sarafrika.elimika.course.repository.CourseRepository;
+import apps.sarafrika.elimika.course.repository.CourseVersionSnapshotRepository;
+import apps.sarafrika.elimika.course.repository.LessonContentRepository;
+import apps.sarafrika.elimika.course.repository.LessonPracticeActivityRepository;
+import apps.sarafrika.elimika.course.repository.LessonRepository;
+import apps.sarafrika.elimika.course.repository.QuizQuestionOptionRepository;
+import apps.sarafrika.elimika.course.repository.QuizQuestionRepository;
+import apps.sarafrika.elimika.course.repository.QuizRepository;
+import apps.sarafrika.elimika.course.service.CourseDraftService;
+import apps.sarafrika.elimika.course.util.CourseRevenueShareValidator;
+import apps.sarafrika.elimika.course.util.enums.ContentStatus;
+import apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * Draft-over-live editing for published courses.
+ * <p>
+ * Cloning a course produces a shadow course row plus a copy of every authoring row beneath
+ * it. Learner data (progress, attempts, submissions) and class scheduling rows are never
+ * cloned — they stay bound to the live tree, which is why promotion updates live rows in
+ * place rather than swapping them.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class CourseDraftServiceImpl implements CourseDraftService {
+
+    private final CourseRepository courseRepository;
+    private final CourseCategoryMappingRepository mappingRepository;
+    private final LessonRepository lessonRepository;
+    private final LessonContentRepository lessonContentRepository;
+    private final QuizRepository quizRepository;
+    private final QuizQuestionRepository quizQuestionRepository;
+    private final QuizQuestionOptionRepository quizQuestionOptionRepository;
+    private final AssignmentRepository assignmentRepository;
+    private final AssignmentAttachmentRepository assignmentAttachmentRepository;
+    private final LessonPracticeActivityRepository practiceActivityRepository;
+    private final CourseVersionSnapshotRepository snapshotRepository;
+    private final ObjectMapper objectMapper;
+
+    private static final String COURSE_NOT_FOUND = "Course not found with UUID: %s";
+    private static final String DRAFT_NOT_FOUND = "No open draft edit for course: %s";
+
+    // ---------------------------------------------------------------- open / find
+
+    @Override
+    public Course openDraft(UUID liveCourseUuid) {
+        Course live = findCourse(liveCourseUuid);
+
+        Optional<Course> existing = courseRepository.findByParentCourseUuid(liveCourseUuid);
+        if (existing.isPresent()) {
+            return existing.get();
+        }
+
+        Course draft = new Course();
+        copyCourseFields(live, draft);
+        draft.setCourseCreatorUuid(live.getCourseCreatorUuid());
+        draft.setParentCourseUuid(live.getUuid());
+        // A draft is DRAFT/inactive/unapproved, which is exactly what the existing catalogue
+        // filters exclude — no new conditions are needed to hide it from learners.
+        draft.setStatus(ContentStatus.DRAFT);
+        draft.setActive(false);
+        draft.setAdminApproved(false);
+        draft = courseRepository.save(draft);
+
+        cloneCategories(live.getUuid(), draft.getUuid());
+        cloneLessonTree(live.getUuid(), draft.getUuid());
+
+        log.info("Opened draft {} for live course {}", draft.getUuid(), liveCourseUuid);
+        return draft;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<Course> findDraft(UUID liveCourseUuid) {
+        return courseRepository.findByParentCourseUuid(liveCourseUuid);
+    }
+
+    // ---------------------------------------------------------------- promote
+
+    @Override
+    public void promote(UUID liveCourseUuid, UUID pendingEditUuid) {
+        Course live = findCourse(liveCourseUuid);
+        Course draft = courseRepository.findByParentCourseUuid(liveCourseUuid)
+                .orElseThrow(() -> new ResourceNotFoundException(String.format(DRAFT_NOT_FOUND, liveCourseUuid)));
+
+        copyCourseFields(draft, live);
+        CourseRevenueShareValidator.validate(live);
+        courseRepository.save(live);
+
+        promoteCategories(draft.getUuid(), live.getUuid());
+        promoteLessons(draft.getUuid(), live.getUuid());
+
+        // Snapshot the resulting live tree before the draft goes away, so the version
+        // history records what actually went live rather than what was proposed.
+        writeSnapshot(live.getUuid(), pendingEditUuid);
+
+        courseRepository.delete(draft);
+        log.info("Promoted draft {} onto live course {}", draft.getUuid(), liveCourseUuid);
+    }
+
+    @Override
+    public void discard(UUID liveCourseUuid) {
+        courseRepository.findByParentCourseUuid(liveCourseUuid).ifPresent(draft -> {
+            courseRepository.delete(draft);
+            log.info("Discarded draft {} for live course {}; live course untouched", draft.getUuid(), liveCourseUuid);
+        });
+    }
+
+    // ---------------------------------------------------------------- cloning
+
+    private void cloneCategories(UUID liveCourseUuid, UUID draftCourseUuid) {
+        for (CourseCategoryMapping mapping : mappingRepository.findByCourseUuid(liveCourseUuid)) {
+            CourseCategoryMapping copy = new CourseCategoryMapping();
+            copy.setCourseUuid(draftCourseUuid);
+            copy.setCategoryUuid(mapping.getCategoryUuid());
+            mappingRepository.save(copy);
+        }
+    }
+
+    private void cloneLessonTree(UUID liveCourseUuid, UUID draftCourseUuid) {
+        for (Lesson liveLesson : lessonRepository.findByCourseUuidOrderByLessonNumberAsc(liveCourseUuid)) {
+            Lesson draftLesson = new Lesson();
+            copyLessonFields(liveLesson, draftLesson);
+            draftLesson.setCourseUuid(draftCourseUuid);
+            draftLesson.setSourceLessonUuid(liveLesson.getUuid());
+            draftLesson = lessonRepository.save(draftLesson);
+
+            cloneLessonContent(liveLesson.getUuid(), draftLesson.getUuid());
+            cloneQuizzes(liveLesson.getUuid(), draftLesson.getUuid());
+            cloneAssignments(liveLesson.getUuid(), draftLesson.getUuid());
+            clonePracticeActivities(liveLesson.getUuid(), draftLesson.getUuid());
+        }
+    }
+
+    private void cloneLessonContent(UUID liveLessonUuid, UUID draftLessonUuid) {
+        for (LessonContent liveContent : lessonContentRepository.findByLessonUuidOrderByDisplayOrderAsc(liveLessonUuid)) {
+            LessonContent copy = new LessonContent();
+            copyContentFields(liveContent, copy);
+            copy.setLessonUuid(draftLessonUuid);
+            copy.setSourceContentUuid(liveContent.getUuid());
+            lessonContentRepository.save(copy);
+        }
+    }
+
+    private void cloneQuizzes(UUID liveLessonUuid, UUID draftLessonUuid) {
+        for (Quiz liveQuiz : quizRepository.findByLessonUuid(liveLessonUuid)) {
+            Quiz draftQuiz = new Quiz();
+            copyQuizFields(liveQuiz, draftQuiz);
+            draftQuiz.setLessonUuid(draftLessonUuid);
+            draftQuiz.setSourceQuizUuid(liveQuiz.getUuid());
+            draftQuiz = quizRepository.save(draftQuiz);
+
+            for (QuizQuestion liveQuestion : quizQuestionRepository.findByQuizUuidOrderByDisplayOrderAsc(liveQuiz.getUuid())) {
+                QuizQuestion draftQuestion = new QuizQuestion();
+                copyQuestionFields(liveQuestion, draftQuestion);
+                draftQuestion.setQuizUuid(draftQuiz.getUuid());
+                draftQuestion.setSourceQuestionUuid(liveQuestion.getUuid());
+                draftQuestion = quizQuestionRepository.save(draftQuestion);
+
+                for (QuizQuestionOption liveOption :
+                        quizQuestionOptionRepository.findByQuestionUuidOrderByDisplayOrderAsc(liveQuestion.getUuid())) {
+                    QuizQuestionOption draftOption = new QuizQuestionOption();
+                    copyOptionFields(liveOption, draftOption);
+                    draftOption.setQuestionUuid(draftQuestion.getUuid());
+                    draftOption.setSourceOptionUuid(liveOption.getUuid());
+                    quizQuestionOptionRepository.save(draftOption);
+                }
+            }
+        }
+    }
+
+    private void cloneAssignments(UUID liveLessonUuid, UUID draftLessonUuid) {
+        for (Assignment liveAssignment : assignmentRepository.findByLessonUuid(liveLessonUuid)) {
+            Assignment draftAssignment = new Assignment();
+            copyAssignmentFields(liveAssignment, draftAssignment);
+            draftAssignment.setLessonUuid(draftLessonUuid);
+            draftAssignment.setSourceAssignmentUuid(liveAssignment.getUuid());
+            draftAssignment = assignmentRepository.save(draftAssignment);
+
+            // Attachments carry no learner references, so they are copied wholesale and
+            // replaced wholesale on promotion.
+            for (AssignmentAttachment liveAttachment :
+                    assignmentAttachmentRepository.findByAssignmentUuid(liveAssignment.getUuid())) {
+                AssignmentAttachment copy = new AssignmentAttachment();
+                copyAttachmentFields(liveAttachment, copy);
+                copy.setAssignmentUuid(draftAssignment.getUuid());
+                assignmentAttachmentRepository.save(copy);
+            }
+        }
+    }
+
+    private void clonePracticeActivities(UUID liveLessonUuid, UUID draftLessonUuid) {
+        for (LessonPracticeActivity liveActivity :
+                practiceActivityRepository.findByLessonUuidOrderByDisplayOrderAsc(liveLessonUuid)) {
+            LessonPracticeActivity copy = new LessonPracticeActivity();
+            copyPracticeActivityFields(liveActivity, copy);
+            copy.setLessonUuid(draftLessonUuid);
+            practiceActivityRepository.save(copy);
+        }
+    }
+
+    // ---------------------------------------------------------------- promotion
+
+    private void promoteCategories(UUID draftCourseUuid, UUID liveCourseUuid) {
+        Set<UUID> desired = mappingRepository.findByCourseUuid(draftCourseUuid).stream()
+                .map(CourseCategoryMapping::getCategoryUuid)
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
+        List<CourseCategoryMapping> current = mappingRepository.findByCourseUuid(liveCourseUuid);
+        Set<UUID> currentUuids = current.stream()
+                .map(CourseCategoryMapping::getCategoryUuid)
+                .collect(Collectors.toSet());
+
+        // Category mappings carry no learner data, so they can be reconciled by delete/insert.
+        current.stream()
+                .filter(m -> !desired.contains(m.getCategoryUuid()))
+                .forEach(mappingRepository::delete);
+
+        desired.stream()
+                .filter(categoryUuid -> !currentUuids.contains(categoryUuid))
+                .forEach(categoryUuid -> {
+                    CourseCategoryMapping mapping = new CourseCategoryMapping();
+                    mapping.setCourseUuid(liveCourseUuid);
+                    mapping.setCategoryUuid(categoryUuid);
+                    mappingRepository.save(mapping);
+                });
+    }
+
+    /**
+     * Reconciles the live lesson tree against the draft. Never deletes: a lesson the edit
+     * removed is deactivated instead, because lesson_progress and content_progress reference
+     * these rows with RESTRICT and learners keep their completion history.
+     */
+    private void promoteLessons(UUID draftCourseUuid, UUID liveCourseUuid) {
+        List<Lesson> draftLessons = lessonRepository.findByCourseUuidOrderByLessonNumberAsc(draftCourseUuid);
+        Map<UUID, Lesson> liveLessons = lessonRepository.findByCourseUuidOrderByLessonNumberAsc(liveCourseUuid).stream()
+                .collect(Collectors.toMap(Lesson::getUuid, Function.identity(), (a, b) -> a, HashMap::new));
+
+        Set<UUID> retained = new LinkedHashSet<>();
+
+        for (Lesson draftLesson : draftLessons) {
+            Lesson target = draftLesson.getSourceLessonUuid() == null
+                    ? null
+                    : liveLessons.get(draftLesson.getSourceLessonUuid());
+
+            if (target == null) {
+                target = new Lesson();
+                target.setCourseUuid(liveCourseUuid);
+            }
+            copyLessonFields(draftLesson, target);
+            target.setCourseUuid(liveCourseUuid);
+            target.setSourceLessonUuid(null);
+            target = lessonRepository.save(target);
+            retained.add(target.getUuid());
+
+            promoteContent(draftLesson.getUuid(), target.getUuid());
+            promoteQuizzes(draftLesson.getUuid(), target.getUuid());
+            promoteAssignments(draftLesson.getUuid(), target.getUuid());
+            promotePracticeActivities(draftLesson.getUuid(), target.getUuid());
+        }
+
+        deactivateRemoved(liveLessons.values(), retained);
+    }
+
+    private void deactivateRemoved(Iterable<Lesson> liveLessons, Set<UUID> retained) {
+        for (Lesson liveLesson : liveLessons) {
+            if (!retained.contains(liveLesson.getUuid()) && !Boolean.FALSE.equals(liveLesson.getActive())) {
+                liveLesson.setActive(false);
+                lessonRepository.save(liveLesson);
+                log.debug("Deactivated lesson {} removed by an approved edit", liveLesson.getUuid());
+            }
+        }
+    }
+
+    private void promoteContent(UUID draftLessonUuid, UUID liveLessonUuid) {
+        List<LessonContent> draftContent = lessonContentRepository.findByLessonUuidOrderByDisplayOrderAsc(draftLessonUuid);
+        Map<UUID, LessonContent> liveContent =
+                lessonContentRepository.findByLessonUuidOrderByDisplayOrderAsc(liveLessonUuid).stream()
+                        .collect(Collectors.toMap(LessonContent::getUuid, Function.identity(), (a, b) -> a, HashMap::new));
+
+        Set<UUID> retained = new LinkedHashSet<>();
+        for (LessonContent draft : draftContent) {
+            LessonContent target = draft.getSourceContentUuid() == null
+                    ? null
+                    : liveContent.get(draft.getSourceContentUuid());
+            if (target == null) {
+                target = new LessonContent();
+            }
+            copyContentFields(draft, target);
+            target.setLessonUuid(liveLessonUuid);
+            target.setSourceContentUuid(null);
+            target = lessonContentRepository.save(target);
+            retained.add(target.getUuid());
+        }
+
+        // content_progress references lesson_contents with RESTRICT, so removed content is
+        // marked not-required and moved out of the way rather than deleted.
+        liveContent.values().stream()
+                .filter(c -> !retained.contains(c.getUuid()))
+                .forEach(c -> {
+                    c.setIsRequired(false);
+                    c.setDisplayOrder(Integer.MAX_VALUE);
+                    lessonContentRepository.save(c);
+                });
+    }
+
+    private void promoteQuizzes(UUID draftLessonUuid, UUID liveLessonUuid) {
+        List<Quiz> draftQuizzes = quizRepository.findByLessonUuid(draftLessonUuid);
+        Map<UUID, Quiz> liveQuizzes = quizRepository.findByLessonUuid(liveLessonUuid).stream()
+                .collect(Collectors.toMap(Quiz::getUuid, Function.identity(), (a, b) -> a, HashMap::new));
+
+        Set<UUID> retained = new LinkedHashSet<>();
+        for (Quiz draft : draftQuizzes) {
+            Quiz target = draft.getSourceQuizUuid() == null ? null : liveQuizzes.get(draft.getSourceQuizUuid());
+            if (target == null) {
+                target = new Quiz();
+            }
+            copyQuizFields(draft, target);
+            target.setLessonUuid(liveLessonUuid);
+            target.setSourceQuizUuid(null);
+            target = quizRepository.save(target);
+            retained.add(target.getUuid());
+
+            promoteQuestions(draft.getUuid(), target.getUuid());
+        }
+
+        liveQuizzes.values().stream()
+                .filter(q -> !retained.contains(q.getUuid()) && !Boolean.FALSE.equals(q.getActive()))
+                .forEach(q -> {
+                    q.setActive(false);
+                    quizRepository.save(q);
+                });
+    }
+
+    private void promoteQuestions(UUID draftQuizUuid, UUID liveQuizUuid) {
+        List<QuizQuestion> draftQuestions = quizQuestionRepository.findByQuizUuidOrderByDisplayOrderAsc(draftQuizUuid);
+        Map<UUID, QuizQuestion> liveQuestions = quizQuestionRepository.findByQuizUuidOrderByDisplayOrderAsc(liveQuizUuid).stream()
+                .collect(Collectors.toMap(QuizQuestion::getUuid, Function.identity(), (a, b) -> a, HashMap::new));
+
+        Set<UUID> retained = new LinkedHashSet<>();
+        for (QuizQuestion draft : draftQuestions) {
+            QuizQuestion target = draft.getSourceQuestionUuid() == null
+                    ? null
+                    : liveQuestions.get(draft.getSourceQuestionUuid());
+            if (target == null) {
+                target = new QuizQuestion();
+            }
+            copyQuestionFields(draft, target);
+            target.setQuizUuid(liveQuizUuid);
+            target.setSourceQuestionUuid(null);
+            target = quizQuestionRepository.save(target);
+            retained.add(target.getUuid());
+
+            promoteOptions(draft.getUuid(), target.getUuid());
+        }
+
+        // quiz_responses reference questions, so a removed question is pushed to the end of
+        // the order rather than deleted.
+        liveQuestions.values().stream()
+                .filter(q -> !retained.contains(q.getUuid()))
+                .forEach(q -> {
+                    q.setDisplayOrder(Integer.MAX_VALUE);
+                    quizQuestionRepository.save(q);
+                });
+    }
+
+    private void promoteOptions(UUID draftQuestionUuid, UUID liveQuestionUuid) {
+        List<QuizQuestionOption> draftOptions =
+                quizQuestionOptionRepository.findByQuestionUuidOrderByDisplayOrderAsc(draftQuestionUuid);
+        Map<UUID, QuizQuestionOption> liveOptions =
+                quizQuestionOptionRepository.findByQuestionUuidOrderByDisplayOrderAsc(liveQuestionUuid).stream()
+                        .collect(Collectors.toMap(QuizQuestionOption::getUuid, Function.identity(), (a, b) -> a, HashMap::new));
+
+        for (QuizQuestionOption draft : draftOptions) {
+            QuizQuestionOption target = draft.getSourceOptionUuid() == null
+                    ? null
+                    : liveOptions.get(draft.getSourceOptionUuid());
+            if (target == null) {
+                target = new QuizQuestionOption();
+            }
+            copyOptionFields(draft, target);
+            target.setQuestionUuid(liveQuestionUuid);
+            target.setSourceOptionUuid(null);
+            quizQuestionOptionRepository.save(target);
+        }
+    }
+
+    private void promoteAssignments(UUID draftLessonUuid, UUID liveLessonUuid) {
+        List<Assignment> draftAssignments = assignmentRepository.findByLessonUuid(draftLessonUuid);
+        Map<UUID, Assignment> liveAssignments = assignmentRepository.findByLessonUuid(liveLessonUuid).stream()
+                .collect(Collectors.toMap(Assignment::getUuid, Function.identity(), (a, b) -> a, HashMap::new));
+
+        Set<UUID> retained = new LinkedHashSet<>();
+        for (Assignment draft : draftAssignments) {
+            Assignment target = draft.getSourceAssignmentUuid() == null
+                    ? null
+                    : liveAssignments.get(draft.getSourceAssignmentUuid());
+            if (target == null) {
+                target = new Assignment();
+            }
+            copyAssignmentFields(draft, target);
+            target.setLessonUuid(liveLessonUuid);
+            target.setSourceAssignmentUuid(null);
+            target = assignmentRepository.save(target);
+            retained.add(target.getUuid());
+
+            replaceAttachments(draft.getUuid(), target.getUuid());
+        }
+
+        // assignment_submissions reference assignments, so a removed assignment is
+        // unpublished rather than deleted.
+        liveAssignments.values().stream()
+                .filter(a -> !retained.contains(a.getUuid()) && !Boolean.FALSE.equals(a.getIsPublished()))
+                .forEach(a -> {
+                    a.setIsPublished(false);
+                    assignmentRepository.save(a);
+                });
+    }
+
+    private void replaceAttachments(UUID draftAssignmentUuid, UUID liveAssignmentUuid) {
+        assignmentAttachmentRepository.findByAssignmentUuid(liveAssignmentUuid)
+                .forEach(assignmentAttachmentRepository::delete);
+        for (AssignmentAttachment draft : assignmentAttachmentRepository.findByAssignmentUuid(draftAssignmentUuid)) {
+            AssignmentAttachment copy = new AssignmentAttachment();
+            copyAttachmentFields(draft, copy);
+            copy.setAssignmentUuid(liveAssignmentUuid);
+            assignmentAttachmentRepository.save(copy);
+        }
+    }
+
+    private void promotePracticeActivities(UUID draftLessonUuid, UUID liveLessonUuid) {
+        practiceActivityRepository.findByLessonUuidOrderByDisplayOrderAsc(liveLessonUuid)
+                .forEach(practiceActivityRepository::delete);
+        for (LessonPracticeActivity draft : practiceActivityRepository.findByLessonUuidOrderByDisplayOrderAsc(draftLessonUuid)) {
+            LessonPracticeActivity copy = new LessonPracticeActivity();
+            copyPracticeActivityFields(draft, copy);
+            copy.setLessonUuid(liveLessonUuid);
+            practiceActivityRepository.save(copy);
+        }
+    }
+
+    // ---------------------------------------------------------------- snapshot
+
+    private void writeSnapshot(UUID courseUuid, UUID pendingEditUuid) {
+        int nextVersion = snapshotRepository.findTopByCourseUuidOrderByVersionNumberDesc(courseUuid)
+                .map(s -> s.getVersionNumber() + 1)
+                .orElse(1);
+
+        CourseVersionSnapshot snapshot = new CourseVersionSnapshot();
+        snapshot.setCourseUuid(courseUuid);
+        snapshot.setVersionNumber(nextVersion);
+        snapshot.setSnapshot(snapshotTree(courseUuid));
+        snapshot.setPendingEditUuid(pendingEditUuid);
+        snapshotRepository.save(snapshot);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public JsonNode snapshotTree(UUID courseUuid) {
+        Course course = findCourse(courseUuid);
+
+        ObjectNode root = objectMapper.createObjectNode();
+        root.set("course", courseNode(course));
+
+        ArrayNode categories = root.putArray("category_uuids");
+        mappingRepository.findByCourseUuid(courseUuid).forEach(m -> categories.add(m.getCategoryUuid().toString()));
+
+        ArrayNode lessons = root.putArray("lessons");
+        for (Lesson lesson : lessonRepository.findByCourseUuidOrderByLessonNumberAsc(courseUuid)) {
+            lessons.add(lessonNode(lesson));
+        }
+        return root;
+    }
+
+    private ObjectNode courseNode(Course course) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("uuid", str(course.getUuid()));
+        node.put("name", course.getName());
+        node.put("description", course.getDescription());
+        node.put("objectives", course.getObjectives());
+        node.put("prerequisites", course.getPrerequisites());
+        node.put("difficulty_uuid", str(course.getDifficultyUuid()));
+        node.put("duration_hours", course.getDurationHours());
+        node.put("duration_minutes", course.getDurationMinutes());
+        node.put("class_limit", course.getClassLimit());
+        node.put("price", course.getPrice() == null ? null : course.getPrice().toPlainString());
+        node.put("minimum_training_fee",
+                course.getMinimumTrainingFee() == null ? null : course.getMinimumTrainingFee().toPlainString());
+        node.put("creator_share_percentage",
+                course.getCreatorSharePercentage() == null ? null : course.getCreatorSharePercentage().toPlainString());
+        node.put("instructor_share_percentage",
+                course.getInstructorSharePercentage() == null ? null : course.getInstructorSharePercentage().toPlainString());
+        node.put("revenue_share_notes", course.getRevenueShareNotes());
+        node.put("age_lower_limit", course.getAgeLowerLimit());
+        node.put("age_upper_limit", course.getAgeUpperLimit());
+        // Storage keys, not resolved URLs — a snapshot must survive a change of host.
+        node.put("thumbnail_url", course.getThumbnailUrl());
+        node.put("banner_url", course.getBannerUrl());
+        node.put("intro_video_url", course.getIntroVideoUrl());
+        return node;
+    }
+
+    private ObjectNode lessonNode(Lesson lesson) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("uuid", str(lesson.getUuid()));
+        node.put("lesson_number", lesson.getLessonNumber());
+        node.put("title", lesson.getTitle());
+        node.put("description", lesson.getDescription());
+        node.put("learning_objectives", lesson.getLearningObjectives());
+        node.put("active", lesson.getActive());
+
+        ArrayNode content = node.putArray("content");
+        for (LessonContent c : lessonContentRepository.findByLessonUuidOrderByDisplayOrderAsc(lesson.getUuid())) {
+            ObjectNode cn = content.addObject();
+            cn.put("uuid", str(c.getUuid()));
+            cn.put("content_type_uuid", str(c.getContentTypeUuid()));
+            cn.put("title", c.getTitle());
+            cn.put("description", c.getDescription());
+            cn.put("content_text", c.getContentText());
+            cn.put("file_url", c.getFileUrl());
+            cn.put("display_order", c.getDisplayOrder());
+            cn.put("is_required", c.getIsRequired());
+        }
+
+        ArrayNode quizzes = node.putArray("quizzes");
+        for (Quiz q : quizRepository.findByLessonUuid(lesson.getUuid())) {
+            ObjectNode qn = quizzes.addObject();
+            qn.put("uuid", str(q.getUuid()));
+            qn.put("title", q.getTitle());
+            qn.put("description", q.getDescription());
+            qn.put("active", q.getActive());
+            ArrayNode questions = qn.putArray("questions");
+            for (QuizQuestion question : quizQuestionRepository.findByQuizUuidOrderByDisplayOrderAsc(q.getUuid())) {
+                ObjectNode qq = questions.addObject();
+                qq.put("uuid", str(question.getUuid()));
+                qq.put("question_text", question.getQuestionText());
+                qq.put("display_order", question.getDisplayOrder());
+            }
+        }
+
+        ArrayNode assignments = node.putArray("assignments");
+        for (Assignment a : assignmentRepository.findByLessonUuid(lesson.getUuid())) {
+            ObjectNode an = assignments.addObject();
+            an.put("uuid", str(a.getUuid()));
+            an.put("title", a.getTitle());
+            an.put("description", a.getDescription());
+            an.put("is_published", a.getIsPublished());
+        }
+        return node;
+    }
+
+    // ---------------------------------------------------------------- diff
+
+    @Override
+    @Transactional(readOnly = true)
+    public CourseEditDiffDTO diff(UUID liveCourseUuid) {
+        Course live = findCourse(liveCourseUuid);
+        Course draft = courseRepository.findByParentCourseUuid(liveCourseUuid)
+                .orElseThrow(() -> new ResourceNotFoundException(String.format(DRAFT_NOT_FOUND, liveCourseUuid)));
+
+        List<CourseEditDiffDTO.FieldChange> changes = new ArrayList<>();
+        ObjectNode liveNode = courseNode(live);
+        ObjectNode draftNode = courseNode(draft);
+        draftNode.fieldNames().forEachRemaining(field -> {
+            if ("uuid".equals(field)) {
+                return;
+            }
+            String liveValue = text(liveNode.get(field));
+            String draftValue = text(draftNode.get(field));
+            if (!Objects.equals(liveValue, draftValue)) {
+                changes.add(new CourseEditDiffDTO.FieldChange(field, liveValue, draftValue));
+            }
+        });
+
+        List<Lesson> draftLessons = lessonRepository.findByCourseUuidOrderByLessonNumberAsc(draft.getUuid());
+        Set<UUID> liveLessonUuids = lessonRepository.findByCourseUuidOrderByLessonNumberAsc(liveCourseUuid).stream()
+                .map(Lesson::getUuid)
+                .collect(Collectors.toSet());
+
+        int added = (int) draftLessons.stream().filter(l -> l.getSourceLessonUuid() == null).count();
+        Set<UUID> keptSources = draftLessons.stream()
+                .map(Lesson::getSourceLessonUuid)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+        int removed = (int) liveLessonUuids.stream().filter(u -> !keptSources.contains(u)).count();
+        int modified = countModifiedLessons(draftLessons);
+
+        return new CourseEditDiffDTO(liveCourseUuid, draft.getUuid(), changes, added, removed, modified);
+    }
+
+    private int countModifiedLessons(List<Lesson> draftLessons) {
+        int modified = 0;
+        for (Lesson draftLesson : draftLessons) {
+            if (draftLesson.getSourceLessonUuid() == null) {
+                continue;
+            }
+            Optional<Lesson> live = lessonRepository.findByUuid(draftLessonSource(draftLesson));
+            if (live.isPresent() && !sameLessonContent(live.get(), draftLesson)) {
+                modified++;
+            }
+        }
+        return modified;
+    }
+
+    private UUID draftLessonSource(Lesson lesson) {
+        return lesson.getSourceLessonUuid();
+    }
+
+    private boolean sameLessonContent(Lesson live, Lesson draft) {
+        return Objects.equals(live.getTitle(), draft.getTitle())
+                && Objects.equals(live.getDescription(), draft.getDescription())
+                && Objects.equals(live.getLearningObjectives(), draft.getLearningObjectives())
+                && Objects.equals(live.getLessonNumber(), draft.getLessonNumber());
+    }
+
+    // ---------------------------------------------------------------- authoring routing
+
+    @Override
+    public UUID resolveEditableCourseUuid(UUID courseUuid) {
+        Course course = findCourse(courseUuid);
+        if (!CoursePendingEditServiceImpl.requiresReview(course)) {
+            return courseUuid;
+        }
+        return openDraft(courseUuid).getUuid();
+    }
+
+    @Override
+    public UUID resolveEditableLessonUuid(UUID courseUuid, UUID lessonUuid) {
+        Course course = findCourse(courseUuid);
+        Lesson lesson = lessonRepository.findByUuid(lessonUuid)
+                .orElseThrow(() -> new ResourceNotFoundException("Lesson not found with UUID: " + lessonUuid));
+
+        if (!CoursePendingEditServiceImpl.requiresReview(course)) {
+            assertBelongsTo(lesson, courseUuid);
+            return lessonUuid;
+        }
+
+        UUID draftCourseUuid = openDraft(courseUuid).getUuid();
+
+        // The creator may name either the live lesson or the draft's copy of it.
+        if (draftCourseUuid.equals(lesson.getCourseUuid())) {
+            return lessonUuid;
+        }
+        assertBelongsTo(lesson, courseUuid);
+
+        return lessonRepository.findByCourseUuidOrderByLessonNumberAsc(draftCourseUuid).stream()
+                .filter(l -> lessonUuid.equals(l.getSourceLessonUuid()))
+                .findFirst()
+                .map(Lesson::getUuid)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Lesson " + lessonUuid + " has no draft counterpart for course " + courseUuid));
+    }
+
+    private void assertBelongsTo(Lesson lesson, UUID courseUuid) {
+        if (!courseUuid.equals(lesson.getCourseUuid())) {
+            throw new ResourceNotFoundException(
+                    "Lesson " + lesson.getUuid() + " does not belong to course " + courseUuid);
+        }
+    }
+
+    @Override
+    public UUID resolveEditableContentUuid(UUID courseUuid, UUID lessonUuid, UUID contentUuid) {
+        UUID targetLessonUuid = resolveEditableLessonUuid(courseUuid, lessonUuid);
+
+        LessonContent content = lessonContentRepository.findByUuid(contentUuid)
+                .orElseThrow(() -> new ResourceNotFoundException("Lesson content not found with UUID: " + contentUuid));
+
+        if (targetLessonUuid.equals(content.getLessonUuid())) {
+            return contentUuid;
+        }
+        if (!lessonUuid.equals(content.getLessonUuid())) {
+            throw new ResourceNotFoundException(
+                    "Lesson content " + contentUuid + " does not belong to lesson " + lessonUuid);
+        }
+
+        return lessonContentRepository.findByLessonUuidOrderByDisplayOrderAsc(targetLessonUuid).stream()
+                .filter(c -> contentUuid.equals(c.getSourceContentUuid()))
+                .findFirst()
+                .map(LessonContent::getUuid)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Lesson content " + contentUuid + " has no draft counterpart for course " + courseUuid));
+    }
+
+    // ---------------------------------------------------------------- field copies
+
+    /**
+     * Copies the authored content of a course. Deliberately excludes identity, ownership and
+     * lifecycle ({@code status}, {@code active}, {@code adminApproved}, {@code parentCourseUuid}),
+     * so promoting a draft can never change whether the live course is published or approved.
+     */
+    private void copyCourseFields(Course from, Course to) {
+        to.setName(from.getName());
+        to.setDifficultyUuid(from.getDifficultyUuid());
+        to.setDescription(from.getDescription());
+        to.setObjectives(from.getObjectives());
+        to.setPrerequisites(from.getPrerequisites());
+        to.setDurationHours(from.getDurationHours());
+        to.setDurationMinutes(from.getDurationMinutes());
+        to.setClassLimit(from.getClassLimit());
+        to.setPrice(from.getPrice());
+        to.setMinimumTrainingFee(from.getMinimumTrainingFee());
+        to.setCreatorSharePercentage(from.getCreatorSharePercentage());
+        to.setInstructorSharePercentage(from.getInstructorSharePercentage());
+        to.setRevenueShareNotes(from.getRevenueShareNotes());
+        to.setAgeLowerLimit(from.getAgeLowerLimit());
+        to.setAgeUpperLimit(from.getAgeUpperLimit());
+        to.setThumbnailUrl(from.getThumbnailUrl());
+        to.setIntroVideoUrl(from.getIntroVideoUrl());
+        to.setBannerUrl(from.getBannerUrl());
+    }
+
+    private void copyLessonFields(Lesson from, Lesson to) {
+        to.setLessonNumber(from.getLessonNumber());
+        to.setTitle(from.getTitle());
+        to.setDescription(from.getDescription());
+        to.setLearningObjectives(from.getLearningObjectives());
+        to.setStatus(from.getStatus());
+        to.setActive(from.getActive());
+    }
+
+    private void copyContentFields(LessonContent from, LessonContent to) {
+        to.setContentTypeUuid(from.getContentTypeUuid());
+        to.setTitle(from.getTitle());
+        to.setDescription(from.getDescription());
+        to.setContentText(from.getContentText());
+        to.setFileUrl(from.getFileUrl());
+        to.setFileSizeBytes(from.getFileSizeBytes());
+        to.setMimeType(from.getMimeType());
+        to.setDisplayOrder(from.getDisplayOrder());
+        to.setIsRequired(from.getIsRequired());
+    }
+
+    private void copyQuizFields(Quiz from, Quiz to) {
+        to.setTitle(from.getTitle());
+        to.setDescription(from.getDescription());
+        to.setInstructions(from.getInstructions());
+        to.setTimeLimitMinutes(from.getTimeLimitMinutes());
+        to.setAttemptsAllowed(from.getAttemptsAllowed());
+        to.setPassingScore(from.getPassingScore());
+        to.setRubricUuid(from.getRubricUuid());
+        to.setStatus(from.getStatus());
+        to.setActive(from.getActive());
+        to.setScope(from.getScope());
+        to.setClassDefinitionUuid(from.getClassDefinitionUuid());
+    }
+
+    private void copyQuestionFields(QuizQuestion from, QuizQuestion to) {
+        to.setQuestionText(from.getQuestionText());
+        to.setQuestionType(from.getQuestionType());
+        to.setPoints(from.getPoints());
+        to.setDisplayOrder(from.getDisplayOrder());
+    }
+
+    private void copyOptionFields(QuizQuestionOption from, QuizQuestionOption to) {
+        to.setOptionText(from.getOptionText());
+        to.setIsCorrect(from.getIsCorrect());
+        to.setDisplayOrder(from.getDisplayOrder());
+    }
+
+    private void copyAssignmentFields(Assignment from, Assignment to) {
+        to.setTitle(from.getTitle());
+        to.setDescription(from.getDescription());
+        to.setInstructions(from.getInstructions());
+        to.setDueDate(from.getDueDate());
+        to.setMaxPoints(from.getMaxPoints());
+        to.setRubricUuid(from.getRubricUuid());
+        to.setSubmissionTypes(from.getSubmissionTypes());
+        to.setIsPublished(from.getIsPublished());
+        to.setScope(from.getScope());
+        to.setClassDefinitionUuid(from.getClassDefinitionUuid());
+    }
+
+    private void copyAttachmentFields(AssignmentAttachment from, AssignmentAttachment to) {
+        to.setOriginalFilename(from.getOriginalFilename());
+        to.setStoredFilename(from.getStoredFilename());
+        to.setFileUrl(from.getFileUrl());
+        to.setFileSizeBytes(from.getFileSizeBytes());
+        to.setMimeType(from.getMimeType());
+    }
+
+    private void copyPracticeActivityFields(LessonPracticeActivity from, LessonPracticeActivity to) {
+        to.setTitle(from.getTitle());
+        to.setInstructions(from.getInstructions());
+        to.setActivityType(from.getActivityType());
+        to.setGrouping(from.getGrouping());
+        to.setEstimatedMinutes(from.getEstimatedMinutes());
+        to.setMaterials(from.getMaterials());
+        to.setExpectedOutput(from.getExpectedOutput());
+        to.setDisplayOrder(from.getDisplayOrder());
+        to.setStatus(from.getStatus());
+        to.setActive(from.getActive());
+    }
+
+    // ---------------------------------------------------------------- helpers
+
+    private Course findCourse(UUID uuid) {
+        return courseRepository.findByUuid(uuid)
+                .orElseThrow(() -> new ResourceNotFoundException(String.format(COURSE_NOT_FOUND, uuid)));
+    }
+
+    private static String str(UUID uuid) {
+        return uuid == null ? null : uuid.toString();
+    }
+
+    private static String text(JsonNode node) {
+        return node == null || node.isNull() ? null : node.asText();
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/course/service/impl/CourseDraftServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/impl/CourseDraftServiceImpl.java
@@ -4,7 +4,11 @@ import apps.sarafrika.elimika.course.dto.CourseEditDiffDTO;
 import apps.sarafrika.elimika.course.model.Assignment;
 import apps.sarafrika.elimika.course.model.AssignmentAttachment;
 import apps.sarafrika.elimika.course.model.Course;
+import apps.sarafrika.elimika.course.model.CourseAssessment;
+import apps.sarafrika.elimika.course.model.CourseAssessmentLineItem;
 import apps.sarafrika.elimika.course.model.CourseCategoryMapping;
+import apps.sarafrika.elimika.course.model.CourseRequirement;
+import apps.sarafrika.elimika.course.model.CourseTrainingRequirement;
 import apps.sarafrika.elimika.course.model.CourseVersionSnapshot;
 import apps.sarafrika.elimika.course.model.Lesson;
 import apps.sarafrika.elimika.course.model.LessonContent;
@@ -14,8 +18,12 @@ import apps.sarafrika.elimika.course.model.QuizQuestion;
 import apps.sarafrika.elimika.course.model.QuizQuestionOption;
 import apps.sarafrika.elimika.course.repository.AssignmentAttachmentRepository;
 import apps.sarafrika.elimika.course.repository.AssignmentRepository;
+import apps.sarafrika.elimika.course.repository.CourseAssessmentLineItemRepository;
+import apps.sarafrika.elimika.course.repository.CourseAssessmentRepository;
 import apps.sarafrika.elimika.course.repository.CourseCategoryMappingRepository;
 import apps.sarafrika.elimika.course.repository.CourseRepository;
+import apps.sarafrika.elimika.course.repository.CourseRequirementRepository;
+import apps.sarafrika.elimika.course.repository.CourseTrainingRequirementRepository;
 import apps.sarafrika.elimika.course.repository.CourseVersionSnapshotRepository;
 import apps.sarafrika.elimika.course.repository.LessonContentRepository;
 import apps.sarafrika.elimika.course.repository.LessonPracticeActivityRepository;
@@ -72,6 +80,10 @@ public class CourseDraftServiceImpl implements CourseDraftService {
     private final AssignmentRepository assignmentRepository;
     private final AssignmentAttachmentRepository assignmentAttachmentRepository;
     private final LessonPracticeActivityRepository practiceActivityRepository;
+    private final CourseAssessmentRepository assessmentRepository;
+    private final CourseAssessmentLineItemRepository lineItemRepository;
+    private final CourseRequirementRepository requirementRepository;
+    private final CourseTrainingRequirementRepository trainingRequirementRepository;
     private final CourseVersionSnapshotRepository snapshotRepository;
     private final ObjectMapper objectMapper;
 
@@ -102,6 +114,9 @@ public class CourseDraftServiceImpl implements CourseDraftService {
 
         cloneCategories(live.getUuid(), draft.getUuid());
         cloneLessonTree(live.getUuid(), draft.getUuid());
+        cloneAssessments(live.getUuid(), draft.getUuid());
+        cloneRequirements(live.getUuid(), draft.getUuid());
+        cloneTrainingRequirements(live.getUuid(), draft.getUuid());
 
         log.info("Opened draft {} for live course {}", draft.getUuid(), liveCourseUuid);
         return draft;
@@ -127,6 +142,9 @@ public class CourseDraftServiceImpl implements CourseDraftService {
 
         promoteCategories(draft.getUuid(), live.getUuid());
         promoteLessons(draft.getUuid(), live.getUuid());
+        promoteAssessments(draft.getUuid(), live.getUuid());
+        promoteRequirements(draft.getUuid(), live.getUuid());
+        promoteTrainingRequirements(draft.getUuid(), live.getUuid());
 
         // Snapshot the resulting live tree before the draft goes away, so the version
         // history records what actually went live rather than what was proposed.
@@ -234,6 +252,46 @@ public class CourseDraftServiceImpl implements CourseDraftService {
             copyPracticeActivityFields(liveActivity, copy);
             copy.setLessonUuid(draftLessonUuid);
             practiceActivityRepository.save(copy);
+        }
+    }
+
+    private void cloneAssessments(UUID liveCourseUuid, UUID draftCourseUuid) {
+        for (CourseAssessment liveAssessment :
+                assessmentRepository.findByCourseUuidOrderByCreatedDateAsc(liveCourseUuid)) {
+            CourseAssessment draftAssessment = new CourseAssessment();
+            copyAssessmentFields(liveAssessment, draftAssessment);
+            draftAssessment.setCourseUuid(draftCourseUuid);
+            draftAssessment.setSourceAssessmentUuid(liveAssessment.getUuid());
+            draftAssessment = assessmentRepository.save(draftAssessment);
+
+            for (CourseAssessmentLineItem liveItem :
+                    lineItemRepository.findByCourseAssessmentUuidOrderByDisplayOrderAscCreatedDateAsc(liveAssessment.getUuid())) {
+                CourseAssessmentLineItem draftItem = new CourseAssessmentLineItem();
+                copyLineItemFields(liveItem, draftItem);
+                draftItem.setCourseAssessmentUuid(draftAssessment.getUuid());
+                draftItem.setSourceLineItemUuid(liveItem.getUuid());
+                lineItemRepository.save(draftItem);
+            }
+        }
+    }
+
+    private void cloneRequirements(UUID liveCourseUuid, UUID draftCourseUuid) {
+        for (CourseRequirement live : requirementRepository.findByCourseUuid(liveCourseUuid)) {
+            CourseRequirement copy = new CourseRequirement();
+            copyRequirementFields(live, copy);
+            copy.setCourseUuid(draftCourseUuid);
+            copy.setSourceRequirementUuid(live.getUuid());
+            requirementRepository.save(copy);
+        }
+    }
+
+    private void cloneTrainingRequirements(UUID liveCourseUuid, UUID draftCourseUuid) {
+        for (CourseTrainingRequirement live : trainingRequirementRepository.findByCourseUuid(liveCourseUuid)) {
+            CourseTrainingRequirement copy = new CourseTrainingRequirement();
+            copyTrainingRequirementFields(live, copy);
+            copy.setCourseUuid(draftCourseUuid);
+            copy.setSourceRequirementUuid(live.getUuid());
+            trainingRequirementRepository.save(copy);
         }
     }
 
@@ -477,6 +535,125 @@ public class CourseDraftServiceImpl implements CourseDraftService {
         }
     }
 
+    /**
+     * Reconciles assessments and their line items in place. Like lessons, removed rows are
+     * deactivated rather than deleted because assessment and line-item scores reference them.
+     */
+    private void promoteAssessments(UUID draftCourseUuid, UUID liveCourseUuid) {
+        List<CourseAssessment> draftAssessments =
+                assessmentRepository.findByCourseUuidOrderByCreatedDateAsc(draftCourseUuid);
+        Map<UUID, CourseAssessment> liveAssessments =
+                assessmentRepository.findByCourseUuidOrderByCreatedDateAsc(liveCourseUuid).stream()
+                        .collect(Collectors.toMap(CourseAssessment::getUuid, Function.identity(), (a, b) -> a, HashMap::new));
+
+        Set<UUID> retained = new LinkedHashSet<>();
+        for (CourseAssessment draft : draftAssessments) {
+            CourseAssessment target = draft.getSourceAssessmentUuid() == null
+                    ? null
+                    : liveAssessments.get(draft.getSourceAssessmentUuid());
+            if (target == null) {
+                target = new CourseAssessment();
+            }
+            copyAssessmentFields(draft, target);
+            target.setCourseUuid(liveCourseUuid);
+            target.setSourceAssessmentUuid(null);
+            target = assessmentRepository.save(target);
+            retained.add(target.getUuid());
+
+            promoteLineItems(draft.getUuid(), target.getUuid());
+        }
+
+        liveAssessments.values().stream()
+                .filter(a -> !retained.contains(a.getUuid()) && !Boolean.FALSE.equals(a.getActive()))
+                .forEach(a -> {
+                    a.setActive(false);
+                    assessmentRepository.save(a);
+                });
+    }
+
+    private void promoteLineItems(UUID draftAssessmentUuid, UUID liveAssessmentUuid) {
+        List<CourseAssessmentLineItem> draftItems =
+                lineItemRepository.findByCourseAssessmentUuidOrderByDisplayOrderAscCreatedDateAsc(draftAssessmentUuid);
+        Map<UUID, CourseAssessmentLineItem> liveItems =
+                lineItemRepository.findByCourseAssessmentUuidOrderByDisplayOrderAscCreatedDateAsc(liveAssessmentUuid).stream()
+                        .collect(Collectors.toMap(CourseAssessmentLineItem::getUuid, Function.identity(), (a, b) -> a, HashMap::new));
+
+        Set<UUID> retained = new LinkedHashSet<>();
+        for (CourseAssessmentLineItem draft : draftItems) {
+            CourseAssessmentLineItem target = draft.getSourceLineItemUuid() == null
+                    ? null
+                    : liveItems.get(draft.getSourceLineItemUuid());
+            if (target == null) {
+                target = new CourseAssessmentLineItem();
+            }
+            copyLineItemFields(draft, target);
+            target.setCourseAssessmentUuid(liveAssessmentUuid);
+            target.setSourceLineItemUuid(null);
+            target = lineItemRepository.save(target);
+            retained.add(target.getUuid());
+        }
+
+        liveItems.values().stream()
+                .filter(i -> !retained.contains(i.getUuid()) && !Boolean.FALSE.equals(i.getActive()))
+                .forEach(i -> {
+                    i.setActive(false);
+                    lineItemRepository.save(i);
+                });
+    }
+
+    /**
+     * Requirements carry no learner data, so a removed one is hard-deleted. Matched ones are
+     * updated in place by source link, preserving their uuids, and new ones are inserted.
+     */
+    private void promoteRequirements(UUID draftCourseUuid, UUID liveCourseUuid) {
+        List<CourseRequirement> draftReqs = requirementRepository.findByCourseUuid(draftCourseUuid);
+        Map<UUID, CourseRequirement> liveReqs = requirementRepository.findByCourseUuid(liveCourseUuid).stream()
+                .collect(Collectors.toMap(CourseRequirement::getUuid, Function.identity(), (a, b) -> a, HashMap::new));
+
+        Set<UUID> retained = new LinkedHashSet<>();
+        for (CourseRequirement draft : draftReqs) {
+            CourseRequirement target = draft.getSourceRequirementUuid() == null
+                    ? null
+                    : liveReqs.get(draft.getSourceRequirementUuid());
+            if (target == null) {
+                target = new CourseRequirement();
+            }
+            copyRequirementFields(draft, target);
+            target.setCourseUuid(liveCourseUuid);
+            target.setSourceRequirementUuid(null);
+            target = requirementRepository.save(target);
+            retained.add(target.getUuid());
+        }
+        liveReqs.values().stream()
+                .filter(r -> !retained.contains(r.getUuid()))
+                .forEach(requirementRepository::delete);
+    }
+
+    private void promoteTrainingRequirements(UUID draftCourseUuid, UUID liveCourseUuid) {
+        List<CourseTrainingRequirement> draftReqs = trainingRequirementRepository.findByCourseUuid(draftCourseUuid);
+        Map<UUID, CourseTrainingRequirement> liveReqs =
+                trainingRequirementRepository.findByCourseUuid(liveCourseUuid).stream()
+                        .collect(Collectors.toMap(CourseTrainingRequirement::getUuid, Function.identity(), (a, b) -> a, HashMap::new));
+
+        Set<UUID> retained = new LinkedHashSet<>();
+        for (CourseTrainingRequirement draft : draftReqs) {
+            CourseTrainingRequirement target = draft.getSourceRequirementUuid() == null
+                    ? null
+                    : liveReqs.get(draft.getSourceRequirementUuid());
+            if (target == null) {
+                target = new CourseTrainingRequirement();
+            }
+            copyTrainingRequirementFields(draft, target);
+            target.setCourseUuid(liveCourseUuid);
+            target.setSourceRequirementUuid(null);
+            target = trainingRequirementRepository.save(target);
+            retained.add(target.getUuid());
+        }
+        liveReqs.values().stream()
+                .filter(r -> !retained.contains(r.getUuid()))
+                .forEach(trainingRequirementRepository::delete);
+    }
+
     // ---------------------------------------------------------------- snapshot
 
     private void writeSnapshot(UUID courseUuid, UUID pendingEditUuid) {
@@ -506,6 +683,43 @@ public class CourseDraftServiceImpl implements CourseDraftService {
         ArrayNode lessons = root.putArray("lessons");
         for (Lesson lesson : lessonRepository.findByCourseUuidOrderByLessonNumberAsc(courseUuid)) {
             lessons.add(lessonNode(lesson));
+        }
+
+        ArrayNode assessments = root.putArray("assessments");
+        for (CourseAssessment assessment : assessmentRepository.findByCourseUuidOrderByCreatedDateAsc(courseUuid)) {
+            ObjectNode an = assessments.addObject();
+            an.put("uuid", str(assessment.getUuid()));
+            an.put("title", assessment.getTitle());
+            an.put("assessment_type", assessment.getAssessmentType());
+            an.put("weight_percentage",
+                    assessment.getWeightPercentage() == null ? null : assessment.getWeightPercentage().toPlainString());
+            an.put("active", assessment.getActive());
+            ArrayNode items = an.putArray("line_items");
+            for (CourseAssessmentLineItem item :
+                    lineItemRepository.findByCourseAssessmentUuidOrderByDisplayOrderAscCreatedDateAsc(assessment.getUuid())) {
+                ObjectNode inode = items.addObject();
+                inode.put("uuid", str(item.getUuid()));
+                inode.put("title", item.getTitle());
+                inode.put("display_order", item.getDisplayOrder());
+                inode.put("active", item.getActive());
+            }
+        }
+
+        ArrayNode requirements = root.putArray("requirements");
+        for (CourseRequirement req : requirementRepository.findByCourseUuid(courseUuid)) {
+            ObjectNode rn = requirements.addObject();
+            rn.put("uuid", str(req.getUuid()));
+            rn.put("requirement_text", req.getRequirementText());
+            rn.put("is_mandatory", req.getIsMandatory());
+        }
+
+        ArrayNode trainingRequirements = root.putArray("training_requirements");
+        for (CourseTrainingRequirement req : trainingRequirementRepository.findByCourseUuid(courseUuid)) {
+            ObjectNode rn = trainingRequirements.addObject();
+            rn.put("uuid", str(req.getUuid()));
+            rn.put("name", req.getName());
+            rn.put("quantity", req.getQuantity());
+            rn.put("unit", req.getUnit());
         }
         return root;
     }
@@ -719,6 +933,97 @@ public class CourseDraftServiceImpl implements CourseDraftService {
                         "Lesson content " + contentUuid + " has no draft counterpart for course " + courseUuid));
     }
 
+    @Override
+    public UUID resolveEditableAssessmentUuid(UUID courseUuid, UUID assessmentUuid) {
+        Course course = findCourse(courseUuid);
+        CourseAssessment assessment = assessmentRepository.findByUuid(assessmentUuid)
+                .orElseThrow(() -> new ResourceNotFoundException("Assessment not found with UUID: " + assessmentUuid));
+
+        if (!CoursePendingEditServiceImpl.requiresReview(course)) {
+            if (!courseUuid.equals(assessment.getCourseUuid())) {
+                throw new ResourceNotFoundException(
+                        "Assessment " + assessmentUuid + " does not belong to course " + courseUuid);
+            }
+            return assessmentUuid;
+        }
+
+        UUID draftCourseUuid = openDraft(courseUuid).getUuid();
+        if (draftCourseUuid.equals(assessment.getCourseUuid())) {
+            return assessmentUuid;
+        }
+        if (!courseUuid.equals(assessment.getCourseUuid())) {
+            throw new ResourceNotFoundException(
+                    "Assessment " + assessmentUuid + " does not belong to course " + courseUuid);
+        }
+        return assessmentRepository.findByCourseUuidOrderByCreatedDateAsc(draftCourseUuid).stream()
+                .filter(a -> assessmentUuid.equals(a.getSourceAssessmentUuid()))
+                .findFirst()
+                .map(CourseAssessment::getUuid)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Assessment " + assessmentUuid + " has no draft counterpart for course " + courseUuid));
+    }
+
+    @Override
+    public UUID resolveEditableRequirementUuid(UUID courseUuid, UUID requirementUuid) {
+        Course course = findCourse(courseUuid);
+        CourseRequirement requirement = requirementRepository.findByUuid(requirementUuid)
+                .orElseThrow(() -> new ResourceNotFoundException("Requirement not found with UUID: " + requirementUuid));
+
+        if (!CoursePendingEditServiceImpl.requiresReview(course)) {
+            if (!courseUuid.equals(requirement.getCourseUuid())) {
+                throw new ResourceNotFoundException(
+                        "Requirement " + requirementUuid + " does not belong to course " + courseUuid);
+            }
+            return requirementUuid;
+        }
+
+        UUID draftCourseUuid = openDraft(courseUuid).getUuid();
+        if (draftCourseUuid.equals(requirement.getCourseUuid())) {
+            return requirementUuid;
+        }
+        if (!courseUuid.equals(requirement.getCourseUuid())) {
+            throw new ResourceNotFoundException(
+                    "Requirement " + requirementUuid + " does not belong to course " + courseUuid);
+        }
+        return requirementRepository.findByCourseUuid(draftCourseUuid).stream()
+                .filter(r -> requirementUuid.equals(r.getSourceRequirementUuid()))
+                .findFirst()
+                .map(CourseRequirement::getUuid)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Requirement " + requirementUuid + " has no draft counterpart for course " + courseUuid));
+    }
+
+    @Override
+    public UUID resolveEditableTrainingRequirementUuid(UUID courseUuid, UUID requirementUuid) {
+        Course course = findCourse(courseUuid);
+        CourseTrainingRequirement requirement = trainingRequirementRepository.findByUuid(requirementUuid)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Training requirement not found with UUID: " + requirementUuid));
+
+        if (!CoursePendingEditServiceImpl.requiresReview(course)) {
+            if (!courseUuid.equals(requirement.getCourseUuid())) {
+                throw new ResourceNotFoundException(
+                        "Training requirement " + requirementUuid + " does not belong to course " + courseUuid);
+            }
+            return requirementUuid;
+        }
+
+        UUID draftCourseUuid = openDraft(courseUuid).getUuid();
+        if (draftCourseUuid.equals(requirement.getCourseUuid())) {
+            return requirementUuid;
+        }
+        if (!courseUuid.equals(requirement.getCourseUuid())) {
+            throw new ResourceNotFoundException(
+                    "Training requirement " + requirementUuid + " does not belong to course " + courseUuid);
+        }
+        return trainingRequirementRepository.findByCourseUuid(draftCourseUuid).stream()
+                .filter(r -> requirementUuid.equals(r.getSourceRequirementUuid()))
+                .findFirst()
+                .map(CourseTrainingRequirement::getUuid)
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Training requirement " + requirementUuid + " has no draft counterpart for course " + courseUuid));
+    }
+
     // ---------------------------------------------------------------- field copies
 
     /**
@@ -814,6 +1119,49 @@ public class CourseDraftServiceImpl implements CourseDraftService {
         to.setFileUrl(from.getFileUrl());
         to.setFileSizeBytes(from.getFileSizeBytes());
         to.setMimeType(from.getMimeType());
+    }
+
+    private void copyAssessmentFields(CourseAssessment from, CourseAssessment to) {
+        to.setAssessmentType(from.getAssessmentType());
+        to.setTitle(from.getTitle());
+        to.setDescription(from.getDescription());
+        to.setWeightPercentage(from.getWeightPercentage());
+        to.setAggregationStrategy(from.getAggregationStrategy());
+        to.setRubricUuid(from.getRubricUuid());
+        to.setSyncClassAttendance(from.getSyncClassAttendance());
+        to.setIsRequired(from.getIsRequired());
+        to.setActive(from.getActive() == null ? Boolean.TRUE : from.getActive());
+    }
+
+    private void copyLineItemFields(CourseAssessmentLineItem from, CourseAssessmentLineItem to) {
+        to.setTitle(from.getTitle());
+        to.setDescription(from.getDescription());
+        to.setItemType(from.getItemType());
+        to.setAssignmentUuid(from.getAssignmentUuid());
+        to.setQuizUuid(from.getQuizUuid());
+        to.setRubricUuid(from.getRubricUuid());
+        to.setScheduledInstanceUuid(from.getScheduledInstanceUuid());
+        to.setMaxScore(from.getMaxScore());
+        to.setWeightPercentage(from.getWeightPercentage());
+        to.setDisplayOrder(from.getDisplayOrder());
+        to.setActive(from.getActive() == null ? Boolean.TRUE : from.getActive());
+        to.setDueAt(from.getDueAt());
+    }
+
+    private void copyRequirementFields(CourseRequirement from, CourseRequirement to) {
+        to.setRequirementType(from.getRequirementType());
+        to.setRequirementText(from.getRequirementText());
+        to.setIsMandatory(from.getIsMandatory());
+    }
+
+    private void copyTrainingRequirementFields(CourseTrainingRequirement from, CourseTrainingRequirement to) {
+        to.setRequirementType(from.getRequirementType());
+        to.setName(from.getName());
+        to.setDescription(from.getDescription());
+        to.setQuantity(from.getQuantity());
+        to.setUnit(from.getUnit());
+        to.setProvidedBy(from.getProvidedBy());
+        to.setIsMandatory(from.getIsMandatory());
     }
 
     private void copyPracticeActivityFields(LessonPracticeActivity from, LessonPracticeActivity to) {

--- a/src/main/java/apps/sarafrika/elimika/course/service/impl/CoursePendingEditServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/impl/CoursePendingEditServiceImpl.java
@@ -1,0 +1,176 @@
+package apps.sarafrika.elimika.course.service.impl;
+
+import apps.sarafrika.elimika.course.dto.CourseEditDiffDTO;
+import apps.sarafrika.elimika.course.dto.CoursePendingEditDTO;
+import apps.sarafrika.elimika.course.dto.CourseVersionSnapshotDTO;
+import apps.sarafrika.elimika.course.factory.CoursePendingEditFactory;
+import apps.sarafrika.elimika.course.factory.CourseVersionSnapshotFactory;
+import apps.sarafrika.elimika.course.model.Course;
+import apps.sarafrika.elimika.course.model.CoursePendingEdit;
+import apps.sarafrika.elimika.course.repository.CoursePendingEditRepository;
+import apps.sarafrika.elimika.course.repository.CourseRepository;
+import apps.sarafrika.elimika.course.repository.CourseVersionSnapshotRepository;
+import apps.sarafrika.elimika.course.service.CourseDraftService;
+import apps.sarafrika.elimika.course.service.CoursePendingEditService;
+import apps.sarafrika.elimika.course.util.enums.ContentStatus;
+import apps.sarafrika.elimika.course.util.enums.PendingEditStatus;
+import apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException;
+import apps.sarafrika.elimika.shared.service.UserContextService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Optional;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class CoursePendingEditServiceImpl implements CoursePendingEditService {
+
+    private final CoursePendingEditRepository pendingEditRepository;
+    private final CourseVersionSnapshotRepository snapshotRepository;
+    private final CourseRepository courseRepository;
+    private final CourseDraftService courseDraftService;
+    private final UserContextService userContextService;
+
+    private static final String COURSE_NOT_FOUND = "Course not found with UUID: %s";
+    private static final String NO_PENDING_EDIT = "No edit awaiting review for course: %s";
+
+    @Override
+    public CoursePendingEditDTO submitOrRefresh(UUID courseUuid, UUID draftCourseUuid) {
+        CoursePendingEdit edit = pendingEditRepository
+                .findByCourseUuidAndStatus(courseUuid, PendingEditStatus.PENDING)
+                .orElseGet(CoursePendingEdit::new);
+
+        edit.setCourseUuid(courseUuid);
+        edit.setDraftCourseUuid(draftCourseUuid);
+        edit.setStatus(PendingEditStatus.PENDING);
+        edit.setSubmittedAt(now());
+        userContextService.getCurrentUserUuidOptional().ifPresent(edit::setSubmittedByUuid);
+
+        CoursePendingEdit saved = pendingEditRepository.save(edit);
+        log.info("Course {} has an edit awaiting review (draft {})", courseUuid, draftCourseUuid);
+        return CoursePendingEditFactory.toDTO(saved);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Optional<CoursePendingEditDTO> findPending(UUID courseUuid) {
+        return pendingEditRepository.findByCourseUuidAndStatus(courseUuid, PendingEditStatus.PENDING)
+                .map(CoursePendingEditFactory::toDTO);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CoursePendingEditDTO> getHistory(UUID courseUuid, Pageable pageable) {
+        return pendingEditRepository.findByCourseUuidOrderBySubmittedAtDesc(courseUuid, pageable)
+                .map(CoursePendingEditFactory::toDTO);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CoursePendingEditDTO> getPendingQueue(Pageable pageable) {
+        return pendingEditRepository
+                .findByStatusOrderBySubmittedAtDesc(PendingEditStatus.PENDING, pageable)
+                .map(CoursePendingEditFactory::toDTO);
+    }
+
+    @Override
+    public CoursePendingEditDTO approve(UUID courseUuid, String reason) {
+        CoursePendingEdit edit = requirePending(courseUuid);
+
+        courseDraftService.promote(courseUuid, edit.getUuid());
+
+        edit.setStatus(PendingEditStatus.APPROVED);
+        // The draft is gone once promoted; the row stays as history.
+        edit.setDraftCourseUuid(null);
+        resolve(edit, reason);
+
+        log.info("Approved and promoted edit {} for course {}", edit.getUuid(), courseUuid);
+        return CoursePendingEditFactory.toDTO(pendingEditRepository.save(edit));
+    }
+
+    @Override
+    public CoursePendingEditDTO reject(UUID courseUuid, String reason) {
+        CoursePendingEdit edit = requirePending(courseUuid);
+
+        courseDraftService.discard(courseUuid);
+
+        edit.setStatus(PendingEditStatus.REJECTED);
+        edit.setDraftCourseUuid(null);
+        resolve(edit, reason);
+
+        // Deliberately does not touch the live course's admin_approved: the published
+        // content was never at fault, only the proposed change was.
+        log.info("Rejected edit {} for course {}; live course untouched", edit.getUuid(), courseUuid);
+        return CoursePendingEditFactory.toDTO(pendingEditRepository.save(edit));
+    }
+
+    @Override
+    public CoursePendingEditDTO withdraw(UUID courseUuid) {
+        CoursePendingEdit edit = requirePending(courseUuid);
+
+        courseDraftService.discard(courseUuid);
+
+        edit.setStatus(PendingEditStatus.WITHDRAWN);
+        edit.setDraftCourseUuid(null);
+        edit.setReviewedAt(now());
+
+        log.info("Creator withdrew edit {} for course {}", edit.getUuid(), courseUuid);
+        return CoursePendingEditFactory.toDTO(pendingEditRepository.save(edit));
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public CourseEditDiffDTO diff(UUID courseUuid) {
+        requirePending(courseUuid);
+        return courseDraftService.diff(courseUuid);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<CourseVersionSnapshotDTO> getVersions(UUID courseUuid, Pageable pageable) {
+        return snapshotRepository.findByCourseUuidOrderByVersionNumberDesc(courseUuid, pageable)
+                .map(CourseVersionSnapshotFactory::toDTO);
+    }
+
+    /**
+     * An edit needs review only once the course is live and approved. Drafts, courses still
+     * awaiting their first approval, and archived courses are edited directly, as before.
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public boolean requiresReview(UUID courseUuid) {
+        Course course = courseRepository.findByUuid(courseUuid)
+                .orElseThrow(() -> new ResourceNotFoundException(String.format(COURSE_NOT_FOUND, courseUuid)));
+        return requiresReview(course);
+    }
+
+    static boolean requiresReview(Course course) {
+        return course.getParentCourseUuid() == null
+                && course.getStatus() == ContentStatus.PUBLISHED
+                && Boolean.TRUE.equals(course.getAdminApproved());
+    }
+
+    private CoursePendingEdit requirePending(UUID courseUuid) {
+        return pendingEditRepository.findByCourseUuidAndStatus(courseUuid, PendingEditStatus.PENDING)
+                .orElseThrow(() -> new ResourceNotFoundException(String.format(NO_PENDING_EDIT, courseUuid)));
+    }
+
+    private void resolve(CoursePendingEdit edit, String reason) {
+        edit.setReviewedAt(now());
+        edit.setReviewReason(reason);
+        userContextService.getCurrentUserUuidOptional().ifPresent(edit::setReviewedByUuid);
+    }
+
+    private static LocalDateTime now() {
+        return LocalDateTime.now(ZoneOffset.UTC);
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/course/service/impl/CourseServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/impl/CourseServiceImpl.java
@@ -7,12 +7,16 @@ import apps.sarafrika.elimika.course.factory.CourseFactory;
 import apps.sarafrika.elimika.course.model.Course;
 import apps.sarafrika.elimika.course.repository.CourseCategoryMappingRepository;
 import apps.sarafrika.elimika.course.repository.CourseRepository;
+import apps.sarafrika.elimika.course.model.CourseCategoryMapping;
 import apps.sarafrika.elimika.course.service.ContentModerationHistoryService;
 import apps.sarafrika.elimika.course.service.CourseCategoryService;
+import apps.sarafrika.elimika.course.service.CourseDraftService;
+import apps.sarafrika.elimika.course.service.CoursePendingEditService;
 import apps.sarafrika.elimika.course.service.CourseEnrollmentService;
 import apps.sarafrika.elimika.course.service.CourseService;
 import apps.sarafrika.elimika.course.service.CourseTrainingRequirementService;
 import apps.sarafrika.elimika.course.service.LessonService;
+import apps.sarafrika.elimika.course.util.CourseRevenueShareValidator;
 import apps.sarafrika.elimika.course.util.CourseSpecificationBuilder;
 import apps.sarafrika.elimika.course.util.enums.ContentStatus;
 import apps.sarafrika.elimika.course.util.enums.EnrollmentStatus;
@@ -61,6 +65,8 @@ public class CourseServiceImpl implements CourseService {
     private final ApplicationEventPublisher eventPublisher;
     private final CourseCreatorLookupService courseCreatorLookupService;
     private final ContentModerationHistoryService contentModerationHistoryService;
+    private final CourseDraftService courseDraftService;
+    private final CoursePendingEditService coursePendingEditService;
 
     private static final String COURSE_NOT_FOUND_TEMPLATE = "Course with ID %s not found";
 
@@ -120,6 +126,14 @@ public class CourseServiceImpl implements CourseService {
         });
     }
 
+    /**
+     * Updates a course, routing material changes to a draft when the course is already live.
+     * <p>
+     * A published, admin-approved course keeps serving its approved content while an edit is
+     * reviewed, so material changes are applied to a shadow draft rather than the live row.
+     * Media fields are cosmetic and apply immediately — a creator should not wait on review
+     * to swap a thumbnail. Courses that are not yet live are edited directly, as before.
+     */
     @Override
     public CourseDTO updateCourse(UUID uuid, CourseDTO courseDTO) {
         log.debug("Updating course: {}", uuid);
@@ -128,15 +142,103 @@ public class CourseServiceImpl implements CourseService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         String.format(COURSE_NOT_FOUND_TEMPLATE, uuid)));
 
-        updateCourseFields(existingCourse, courseDTO);
-        validateRevenueShare(existingCourse);
-        Course updatedCourse = courseRepository.save(existingCourse);
+        if (!CoursePendingEditServiceImpl.requiresReview(existingCourse)) {
+            updateCourseFields(existingCourse, courseDTO);
+            validateRevenueShare(existingCourse);
+            courseRepository.save(existingCourse);
+            handleCategoryAssignments(uuid, courseDTO);
+            return getCourseByUuid(uuid);
+        }
 
-        // Handle category assignments if provided
-        handleCategoryAssignments(uuid, courseDTO);
+        applyCosmeticFields(existingCourse, courseDTO);
+        courseRepository.save(existingCourse);
 
-        // Fetch the updated course with category names for response
+        if (hasMaterialChanges(uuid, courseDTO)) {
+            Course draft = courseDraftService.openDraft(uuid);
+            updateCourseFields(draft, courseDTO);
+            validateRevenueShare(draft);
+            courseRepository.save(draft);
+            handleCategoryAssignments(draft.getUuid(), courseDTO);
+            coursePendingEditService.submitOrRefresh(uuid, draft.getUuid());
+            log.info("Material changes to live course {} routed to draft {} for review", uuid, draft.getUuid());
+        }
+
+        // Returns the live course: the creator's material changes are not live yet.
         return getCourseByUuid(uuid);
+    }
+
+    /**
+     * Media fields only. These apply to the live course immediately and never trigger review.
+     */
+    private void applyCosmeticFields(Course course, CourseDTO dto) {
+        if (dto.thumbnailUrl() != null) {
+            course.setThumbnailUrl(FileUrlResolver.toStorableValue(dto.thumbnailUrl()));
+        }
+        if (dto.introVideoUrl() != null) {
+            course.setIntroVideoUrl(FileUrlResolver.toStorableValue(dto.introVideoUrl()));
+        }
+        if (dto.bannerUrl() != null) {
+            course.setBannerUrl(FileUrlResolver.toStorableValue(dto.bannerUrl()));
+        }
+    }
+
+    /**
+     * Whether the incoming payload actually changes anything material.
+     * <p>
+     * Compared against the open draft when there is one, so a creator refining an edit keeps
+     * building on their working copy, and re-sending an unchanged value never re-opens review.
+     */
+    private boolean hasMaterialChanges(UUID liveCourseUuid, CourseDTO dto) {
+        Course baseline = courseDraftService.findDraft(liveCourseUuid)
+                .orElseGet(() -> courseRepository.findByUuid(liveCourseUuid)
+                        .orElseThrow(() -> new ResourceNotFoundException(
+                                String.format(COURSE_NOT_FOUND_TEMPLATE, liveCourseUuid))));
+
+        if (differs(dto.name(), baseline.getName())
+                || differs(dto.description(), baseline.getDescription())
+                || differs(dto.objectives(), baseline.getObjectives())
+                || differs(dto.prerequisites(), baseline.getPrerequisites())
+                || differs(dto.difficultyUuid(), baseline.getDifficultyUuid())
+                || differs(dto.durationHours(), baseline.getDurationHours())
+                || differs(dto.durationMinutes(), baseline.getDurationMinutes())
+                || differs(dto.classLimit(), baseline.getClassLimit())
+                || differs(dto.revenueShareNotes(), baseline.getRevenueShareNotes())
+                || differs(dto.ageLowerLimit(), baseline.getAgeLowerLimit())
+                || differs(dto.ageUpperLimit(), baseline.getAgeUpperLimit())) {
+            return true;
+        }
+
+        // Money is compared by value, so 1500 and 1500.00 are not treated as a change.
+        if (differsNumerically(dto.price(), baseline.getPrice())
+                || differsNumerically(dto.minimumTrainingFee(), baseline.getMinimumTrainingFee())
+                || differsNumerically(dto.creatorSharePercentage(), baseline.getCreatorSharePercentage())
+                || differsNumerically(dto.instructorSharePercentage(), baseline.getInstructorSharePercentage())) {
+            return true;
+        }
+
+        return categoriesDiffer(baseline.getUuid(), dto.categoryUuids());
+    }
+
+    private boolean categoriesDiffer(UUID baselineCourseUuid, Set<UUID> incoming) {
+        if (incoming == null) {
+            return false;
+        }
+        Set<UUID> current = mappingRepository.findByCourseUuid(baselineCourseUuid).stream()
+                .map(CourseCategoryMapping::getCategoryUuid)
+                .collect(java.util.stream.Collectors.toSet());
+        return !current.equals(incoming);
+    }
+
+    /** A null incoming value means "not supplied", never "clear it". */
+    private boolean differs(Object incoming, Object current) {
+        return incoming != null && !incoming.equals(current);
+    }
+
+    private boolean differsNumerically(BigDecimal incoming, BigDecimal current) {
+        if (incoming == null) {
+            return false;
+        }
+        return current == null || incoming.compareTo(current) != 0;
     }
 
     @Override
@@ -434,25 +536,7 @@ public class CourseServiceImpl implements CourseService {
     }
 
     private void validateRevenueShare(Course course) {
-        BigDecimal creatorShare = course.getCreatorSharePercentage();
-        BigDecimal instructorShare = course.getInstructorSharePercentage();
-
-        if (creatorShare == null || instructorShare == null) {
-            throw new IllegalArgumentException("Creator and instructor share percentages are required for a course");
-        }
-
-        if (creatorShare.compareTo(BigDecimal.ZERO) < 0 || instructorShare.compareTo(BigDecimal.ZERO) < 0) {
-            throw new IllegalArgumentException("Revenue share percentages cannot be negative");
-        }
-
-        BigDecimal hundred = new BigDecimal("100.00");
-        if (creatorShare.compareTo(hundred) > 0 || instructorShare.compareTo(hundred) > 0) {
-            throw new IllegalArgumentException("Revenue share percentages cannot exceed 100%");
-        }
-
-        if (creatorShare.add(instructorShare).compareTo(hundred) != 0) {
-            throw new IllegalArgumentException("Creator and instructor share percentages must add up to 100%");
-        }
+        CourseRevenueShareValidator.validate(course);
     }
 
     /**
@@ -529,12 +613,10 @@ public class CourseServiceImpl implements CourseService {
         if (dto.bannerUrl() != null) {
             existingCourse.setBannerUrl(FileUrlResolver.toStorableValue(dto.bannerUrl()));
         }
-        if (dto.status() != null) {
-            existingCourse.setStatus(dto.status());
-        }
-        if (dto.active() != null) {
-            existingCourse.setActive(dto.active());
-        }
+        // status and active are deliberately not settable here. Lifecycle changes go through
+        // publishCourse/unpublishCourse/archiveCourse, which enforce the readiness checks and
+        // the review workflow. Accepting them on a plain PUT let a client demote a live course
+        // to draft — which is exactly how editing used to unpublish a published course.
     }
 
     /**

--- a/src/main/java/apps/sarafrika/elimika/course/util/CourseRevenueShareValidator.java
+++ b/src/main/java/apps/sarafrika/elimika/course/util/CourseRevenueShareValidator.java
@@ -1,0 +1,40 @@
+package apps.sarafrika.elimika.course.util;
+
+import apps.sarafrika.elimika.course.model.Course;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+/**
+ * Validates that a course splits revenue between its creator and instructor coherently.
+ * <p>
+ * Extracted from CourseServiceImpl so the draft-promotion path can apply the same rule to
+ * the merged live course without depending on CourseService (which would be circular).
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CourseRevenueShareValidator {
+
+    private static final BigDecimal HUNDRED = new BigDecimal("100.00");
+
+    public static void validate(Course course) {
+        BigDecimal creatorShare = course.getCreatorSharePercentage();
+        BigDecimal instructorShare = course.getInstructorSharePercentage();
+
+        if (creatorShare == null || instructorShare == null) {
+            throw new IllegalArgumentException("Creator and instructor share percentages are required for a course");
+        }
+
+        if (creatorShare.compareTo(BigDecimal.ZERO) < 0 || instructorShare.compareTo(BigDecimal.ZERO) < 0) {
+            throw new IllegalArgumentException("Revenue share percentages cannot be negative");
+        }
+
+        if (creatorShare.compareTo(HUNDRED) > 0 || instructorShare.compareTo(HUNDRED) > 0) {
+            throw new IllegalArgumentException("Revenue share percentages cannot exceed 100%");
+        }
+
+        if (creatorShare.add(instructorShare).compareTo(HUNDRED) != 0) {
+            throw new IllegalArgumentException("Creator and instructor share percentages must add up to 100%");
+        }
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/course/util/converter/PendingEditStatusConverter.java
+++ b/src/main/java/apps/sarafrika/elimika/course/util/converter/PendingEditStatusConverter.java
@@ -1,0 +1,23 @@
+package apps.sarafrika.elimika.course.util.converter;
+
+import apps.sarafrika.elimika.course.util.enums.PendingEditStatus;
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * Converts the PendingEditStatus enum to its explicitly defined string value for the database,
+ * and back to the enum from the database string.
+ */
+@Converter(autoApply = true)
+public class PendingEditStatusConverter implements AttributeConverter<PendingEditStatus, String> {
+
+    @Override
+    public String convertToDatabaseColumn(PendingEditStatus attribute) {
+        return attribute != null ? attribute.getValue() : null;
+    }
+
+    @Override
+    public PendingEditStatus convertToEntityAttribute(String dbData) {
+        return dbData != null ? PendingEditStatus.fromValue(dbData) : null;
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/course/util/enums/PendingEditStatus.java
+++ b/src/main/java/apps/sarafrika/elimika/course/util/enums/PendingEditStatus.java
@@ -1,0 +1,53 @@
+package apps.sarafrika.elimika.course.util.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Lifecycle of a course edit that is awaiting, or has been through, admin review.
+ * <p>
+ * Distinct from {@link ContentStatus}, which describes the course itself. A live course
+ * with a PENDING edit stays PUBLISHED and admin-approved throughout review.
+ */
+public enum PendingEditStatus {
+    PENDING("pending"),
+    APPROVED("approved"),
+    REJECTED("rejected"),
+    WITHDRAWN("withdrawn");
+
+    private final String value;
+    private static final Map<String, PendingEditStatus> VALUE_MAP = new HashMap<>();
+
+    static {
+        for (PendingEditStatus status : PendingEditStatus.values()) {
+            VALUE_MAP.put(status.value, status);
+            VALUE_MAP.put(status.value.toUpperCase(), status);
+        }
+    }
+
+    PendingEditStatus(String value) {
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @JsonCreator
+    public static PendingEditStatus fromValue(String value) {
+        PendingEditStatus status = VALUE_MAP.get(value);
+        if (status == null) {
+            throw new IllegalArgumentException("Unknown PendingEditStatus: " + value);
+        }
+        return status;
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/shared/controller/CourseController.java
+++ b/src/main/java/apps/sarafrika/elimika/shared/controller/CourseController.java
@@ -832,9 +832,10 @@ public class CourseController {
 
                     **Authorization:** Only the course owner.
                     """,
+            // Response schemas are inferred from the return type so the generated clients see
+            // the real ApiResponse envelope rather than the bare payload.
             responses = {
-                    @ApiResponse(responseCode = "200", description = "Pending edit retrieved",
-                            content = @Content(schema = @Schema(implementation = CoursePendingEditDTO.class))),
+                    @ApiResponse(responseCode = "200", description = "Pending edit retrieved"),
                     @ApiResponse(responseCode = "204", description = "No edit awaiting review"),
                     @ApiResponse(responseCode = "403", description = "Not the course owner")
             }
@@ -949,16 +950,20 @@ public class CourseController {
             @RequestParam(value = "description", required = false) String description,
             @RequestParam(value = "is_required", required = false) Boolean isRequired
     ) {
+        // On a live course the media attaches to the draft's copy of the lesson, so it is
+        // reviewed with the rest of the edit rather than appearing live immediately.
+        UUID targetLessonUuid = courseDraftService.resolveEditableLessonUuid(courseUuid, lessonUuid);
+
         String folder = storageProperties.getFolders().getCourseMaterials()
                 + "/" + courseUuid
-                + "/lessons/" + lessonUuid;
+                + "/lessons/" + targetLessonUuid;
 
         StoredMedia storedMedia = mediaStorageService.store(new MediaUploadRequest(
-                file, MediaCategory.DOCUMENT, folder, MediaOwnerType.LESSON_CONTENT, lessonUuid, null));
+                file, MediaCategory.DOCUMENT, folder, MediaOwnerType.LESSON_CONTENT, targetLessonUuid, null));
 
         LessonContentDTO requestDto = new LessonContentDTO(
                 null,
-                lessonUuid,
+                targetLessonUuid,
                 contentTypeUuid,
                 title,
                 description,
@@ -1037,7 +1042,11 @@ public class CourseController {
             @PathVariable UUID courseUuid,
             @PathVariable UUID lessonUuid,
             @RequestBody List<UUID> contentUuids) {
-        lessonContentService.reorderContent(lessonUuid, contentUuids);
+        UUID targetLessonUuid = courseDraftService.resolveEditableLessonUuid(courseUuid, lessonUuid);
+        List<UUID> targetContentUuids = contentUuids.stream()
+                .map(contentUuid -> courseDraftService.resolveEditableContentUuid(courseUuid, lessonUuid, contentUuid))
+                .toList();
+        lessonContentService.reorderContent(targetLessonUuid, targetContentUuids);
         return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
                 .success("Content reordered successfully", "Lesson content order updated"));
     }
@@ -1053,7 +1062,9 @@ public class CourseController {
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseAssessmentDTO>> addCourseAssessment(
             @PathVariable UUID courseUuid,
             @Valid @RequestBody CourseAssessmentDTO assessmentDTO) {
-        CourseAssessmentDTO createdAssessment = courseAssessmentService.createCourseAssessment(courseUuid, assessmentDTO);
+        UUID targetCourseUuid = courseDraftService.resolveEditableCourseUuid(courseUuid);
+        CourseAssessmentDTO createdAssessment =
+                courseAssessmentService.createCourseAssessment(targetCourseUuid, assessmentDTO);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(apps.sarafrika.elimika.shared.dto.ApiResponse
                         .success(createdAssessment, "Assessment added successfully"));
@@ -1085,7 +1096,10 @@ public class CourseController {
             @PathVariable UUID courseUuid,
             @PathVariable UUID assessmentUuid,
             @Valid @RequestBody CourseAssessmentDTO assessmentDTO) {
-        CourseAssessmentDTO updatedAssessment = courseAssessmentService.updateCourseAssessment(courseUuid, assessmentUuid, assessmentDTO);
+        UUID targetCourseUuid = courseDraftService.resolveEditableCourseUuid(courseUuid);
+        UUID targetAssessmentUuid = courseDraftService.resolveEditableAssessmentUuid(courseUuid, assessmentUuid);
+        CourseAssessmentDTO updatedAssessment =
+                courseAssessmentService.updateCourseAssessment(targetCourseUuid, targetAssessmentUuid, assessmentDTO);
         return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
                 .success(updatedAssessment, "Assessment updated successfully"));
     }
@@ -1099,7 +1113,8 @@ public class CourseController {
     public ResponseEntity<Void> deleteCourseAssessment(
             @PathVariable UUID courseUuid,
             @PathVariable UUID assessmentUuid) {
-        courseAssessmentService.deleteCourseAssessment(assessmentUuid);
+        courseAssessmentService.deleteCourseAssessment(
+                courseDraftService.resolveEditableAssessmentUuid(courseUuid, assessmentUuid));
         return ResponseEntity.noContent().build();
     }
 
@@ -1114,7 +1129,8 @@ public class CourseController {
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseRequirementDTO>> addCourseRequirement(
             @PathVariable UUID courseUuid,
             @Valid @RequestBody CourseRequirementDTO requirementDTO) {
-        CourseRequirementDTO createdRequirement = courseRequirementService.createCourseRequirement(courseUuid, requirementDTO);
+        CourseRequirementDTO createdRequirement = courseRequirementService.createCourseRequirement(
+                courseDraftService.resolveEditableCourseUuid(courseUuid), requirementDTO);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(apps.sarafrika.elimika.shared.dto.ApiResponse
                         .success(createdRequirement, "Requirement added successfully"));
@@ -1146,7 +1162,10 @@ public class CourseController {
             @PathVariable UUID courseUuid,
             @PathVariable UUID requirementUuid,
             @Valid @RequestBody CourseRequirementDTO requirementDTO) {
-        CourseRequirementDTO updatedRequirement = courseRequirementService.updateCourseRequirement(courseUuid, requirementUuid, requirementDTO);
+        CourseRequirementDTO updatedRequirement = courseRequirementService.updateCourseRequirement(
+                courseDraftService.resolveEditableCourseUuid(courseUuid),
+                courseDraftService.resolveEditableRequirementUuid(courseUuid, requirementUuid),
+                requirementDTO);
         return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
                 .success(updatedRequirement, "Requirement updated successfully"));
     }
@@ -1160,7 +1179,9 @@ public class CourseController {
     public ResponseEntity<Void> deleteCourseRequirement(
             @PathVariable UUID courseUuid,
             @PathVariable UUID requirementUuid) {
-        courseRequirementService.deleteCourseRequirement(courseUuid, requirementUuid);
+        courseRequirementService.deleteCourseRequirement(
+                courseDraftService.resolveEditableCourseUuid(courseUuid),
+                courseDraftService.resolveEditableRequirementUuid(courseUuid, requirementUuid));
         return ResponseEntity.noContent().build();
     }
 
@@ -1175,7 +1196,8 @@ public class CourseController {
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseTrainingRequirementDTO>> addCourseTrainingRequirement(
             @PathVariable UUID courseUuid,
             @Valid @RequestBody CourseTrainingRequirementDTO requirementDTO) {
-        CourseTrainingRequirementDTO createdRequirement = courseTrainingRequirementService.create(courseUuid, requirementDTO);
+        CourseTrainingRequirementDTO createdRequirement = courseTrainingRequirementService.create(
+                courseDraftService.resolveEditableCourseUuid(courseUuid), requirementDTO);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(apps.sarafrika.elimika.shared.dto.ApiResponse
                         .success(createdRequirement, "Training requirement added successfully"));
@@ -1207,7 +1229,10 @@ public class CourseController {
             @PathVariable UUID courseUuid,
             @PathVariable UUID requirementUuid,
             @Valid @RequestBody CourseTrainingRequirementDTO requirementDTO) {
-        CourseTrainingRequirementDTO updatedRequirement = courseTrainingRequirementService.update(courseUuid, requirementUuid, requirementDTO);
+        CourseTrainingRequirementDTO updatedRequirement = courseTrainingRequirementService.update(
+                courseDraftService.resolveEditableCourseUuid(courseUuid),
+                courseDraftService.resolveEditableTrainingRequirementUuid(courseUuid, requirementUuid),
+                requirementDTO);
         return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
                 .success(updatedRequirement, "Training requirement updated successfully"));
     }
@@ -1221,7 +1246,9 @@ public class CourseController {
     public ResponseEntity<Void> deleteCourseTrainingRequirement(
             @PathVariable UUID courseUuid,
             @PathVariable UUID requirementUuid) {
-        courseTrainingRequirementService.delete(courseUuid, requirementUuid);
+        courseTrainingRequirementService.delete(
+                courseDraftService.resolveEditableCourseUuid(courseUuid),
+                courseDraftService.resolveEditableTrainingRequirementUuid(courseUuid, requirementUuid));
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/apps/sarafrika/elimika/shared/controller/CourseController.java
+++ b/src/main/java/apps/sarafrika/elimika/shared/controller/CourseController.java
@@ -30,6 +30,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
@@ -55,6 +56,8 @@ public class CourseController {
     public static final String API_ROOT_PATH = "/api/v1/courses";
 
     private final CourseService courseService;
+    private final CourseDraftService courseDraftService;
+    private final CoursePendingEditService coursePendingEditService;
     private final LessonService lessonService;
     private final LessonContentService lessonContentService;
     private final CourseAssessmentService courseAssessmentService;
@@ -100,6 +103,7 @@ public class CourseController {
                     @ApiResponse(responseCode = "400", description = "Invalid request data or category not found")
             }
     )
+    @PreAuthorize("@domainSecurityService.isCourseCreator()")
     @PostMapping
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseDTO>> createCourse(
             @Valid @RequestBody CourseDTO courseDTO) {
@@ -192,8 +196,8 @@ public class CourseController {
                     @ApiResponse(responseCode = "403", description = "Not authorized - only course owner can update")
             }
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#uuid)")
     @PutMapping("/{uuid}")
-    @org.springframework.security.access.prepost.PreAuthorize("@courseSecurityService.isCourseOwner(#uuid)")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseDTO>> updateCourse(
             @PathVariable UUID uuid,
             @Valid @RequestBody CourseDTO courseDTO) {
@@ -227,6 +231,7 @@ public class CourseController {
                     @ApiResponse(responseCode = "404", description = "Course not found")
             }
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#uuid)")
     @PostMapping("/{uuid}/unpublish")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseDTO>> unpublishCourse(
             @PathVariable UUID uuid) {
@@ -257,6 +262,7 @@ public class CourseController {
                     @ApiResponse(responseCode = "404", description = "Course not found")
             }
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#uuid)")
     @PostMapping("/{uuid}/archive")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseDTO>> archiveCourse(
             @PathVariable UUID uuid) {
@@ -298,6 +304,7 @@ public class CourseController {
                     @ApiResponse(responseCode = "404", description = "Course not found")
             }
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#uuid)")
     @DeleteMapping("/{uuid}")
     public ResponseEntity<Void> deleteCourse(@PathVariable UUID uuid) {
         courseService.deleteCourse(uuid);
@@ -322,6 +329,7 @@ public class CourseController {
             summary = "Remove category from course",
             description = "Removes a specific category from a course without affecting other categories."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @DeleteMapping("/{courseUuid}/categories/{categoryUuid}")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<String>> removeCategoryFromCourse(
             @PathVariable UUID courseUuid,
@@ -335,6 +343,7 @@ public class CourseController {
             summary = "Remove all categories from course",
             description = "Removes all category associations from a course."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @DeleteMapping("/{courseUuid}/categories")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<String>> removeAllCategoriesFromCourse(
             @PathVariable UUID courseUuid) {
@@ -388,6 +397,7 @@ public class CourseController {
                     @ApiResponse(responseCode = "400", description = "Course not ready for publishing")
             }
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#uuid)")
     @PostMapping("/{uuid}/publish")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseDTO>> publishCourse(
             @PathVariable UUID uuid) {
@@ -446,6 +456,7 @@ public class CourseController {
                     )
             }
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#uuid)")
     @PostMapping(value = "/{uuid}/thumbnail", consumes = MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseDTO>> uploadCourseThumbnail(
             @Parameter(
@@ -507,6 +518,7 @@ public class CourseController {
                     )
             }
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#uuid)")
     @PostMapping(value = "/{uuid}/banner", consumes = MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseDTO>> uploadCourseBanner(
             @Parameter(
@@ -570,6 +582,7 @@ public class CourseController {
                     )
             }
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#uuid)")
     @PostMapping(value = "/{uuid}/intro-video", consumes = MULTIPART_FORM_DATA_VALUE, produces = APPLICATION_JSON_VALUE)
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseDTO>> uploadCourseIntroVideo(
             @Parameter(
@@ -675,11 +688,15 @@ public class CourseController {
             summary = "Add lesson to course",
             description = "Creates a new lesson associated with the specified course."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PostMapping("/{courseUuid}/lessons")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<LessonDTO>> addCourseLesson(
             @PathVariable UUID courseUuid,
             @Valid @RequestBody LessonDTO lessonDTO) {
-        LessonDTO createdLesson = lessonService.createLesson(lessonDTO);
+        // The lesson always belongs to the course in the path, never to whatever the body
+        // claims, and lands on the draft when the course is live and awaiting review.
+        UUID targetCourseUuid = courseDraftService.resolveEditableCourseUuid(courseUuid);
+        LessonDTO createdLesson = lessonService.createLesson(lessonDTO.withCourseUuid(targetCourseUuid));
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(apps.sarafrika.elimika.shared.dto.ApiResponse
                         .success(createdLesson, "Lesson added successfully"));
@@ -774,12 +791,15 @@ public class CourseController {
             summary = "Update course lesson",
             description = "Updates a specific lesson within a course."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PutMapping("/{courseUuid}/lessons/{lessonUuid}")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<LessonDTO>> updateCourseLesson(
             @PathVariable UUID courseUuid,
             @PathVariable UUID lessonUuid,
             @Valid @RequestBody LessonDTO lessonDTO) {
-        LessonDTO updatedLesson = lessonService.updateLesson(lessonUuid, lessonDTO);
+        UUID targetLessonUuid = courseDraftService.resolveEditableLessonUuid(courseUuid, lessonUuid);
+        UUID targetCourseUuid = courseDraftService.resolveEditableCourseUuid(courseUuid);
+        LessonDTO updatedLesson = lessonService.updateLesson(targetLessonUuid, lessonDTO.withCourseUuid(targetCourseUuid));
         return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
                 .success(updatedLesson, "Lesson updated successfully"));
     }
@@ -788,12 +808,93 @@ public class CourseController {
             summary = "Delete course lesson",
             description = "Removes a lesson from a course including all associated content."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @DeleteMapping("/{courseUuid}/lessons/{lessonUuid}")
     public ResponseEntity<Void> deleteCourseLesson(
             @PathVariable UUID courseUuid,
             @PathVariable UUID lessonUuid) {
-        lessonService.deleteLesson(lessonUuid);
+        // On a live course this removes the lesson from the draft only; the live lesson is
+        // deactivated when an admin approves the edit, so learner progress survives.
+        lessonService.deleteLesson(courseDraftService.resolveEditableLessonUuid(courseUuid, lessonUuid));
         return ResponseEntity.noContent().build();
+    }
+
+    // ===== PENDING EDITS (course creator) =====
+
+    @Operation(
+            summary = "Get this course's pending edit",
+            description = """
+                    Returns the edit awaiting admin review for this course, if there is one.
+
+                    While an edit is pending the course stays published and keeps serving its
+                    last-approved content to learners. The proposed content lives on the draft
+                    course referenced by `draft_course_uuid`, which only the course owner can see.
+
+                    **Authorization:** Only the course owner.
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Pending edit retrieved",
+                            content = @Content(schema = @Schema(implementation = CoursePendingEditDTO.class))),
+                    @ApiResponse(responseCode = "204", description = "No edit awaiting review"),
+                    @ApiResponse(responseCode = "403", description = "Not the course owner")
+            }
+    )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#uuid)")
+    @GetMapping("/{uuid}/pending-edit")
+    public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CoursePendingEditDTO>> getPendingEdit(
+            @Parameter(description = "UUID of the course") @PathVariable UUID uuid) {
+        return coursePendingEditService.findPending(uuid)
+                .map(edit -> ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
+                        .success(edit, "Pending edit retrieved successfully")))
+                .orElseGet(() -> ResponseEntity.noContent().build());
+    }
+
+    @Operation(
+            summary = "Withdraw this course's pending edit",
+            description = """
+                    Abandons the edit awaiting review and discards the draft. The live course is
+                    not affected — it was never modified while the edit was pending.
+
+                    **Authorization:** Only the course owner.
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Pending edit withdrawn"),
+                    @ApiResponse(responseCode = "404", description = "No edit awaiting review"),
+                    @ApiResponse(responseCode = "403", description = "Not the course owner")
+            }
+    )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#uuid)")
+    @DeleteMapping("/{uuid}/pending-edit")
+    public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CoursePendingEditDTO>> withdrawPendingEdit(
+            @Parameter(description = "UUID of the course") @PathVariable UUID uuid) {
+        CoursePendingEditDTO withdrawn = coursePendingEditService.withdraw(uuid);
+        return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
+                .success(withdrawn, "Pending edit withdrawn successfully"));
+    }
+
+    @Operation(
+            summary = "Get this course's approved version history",
+            description = """
+                    Returns each approved version of the course's content, newest first. A version
+                    is recorded every time an admin approves an edit and it is promoted onto the
+                    live course.
+
+                    **Authorization:** Only the course owner.
+                    """,
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Version history retrieved"),
+                    @ApiResponse(responseCode = "403", description = "Not the course owner")
+            }
+    )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#uuid)")
+    @GetMapping("/{uuid}/versions")
+    public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<PagedDTO<CourseVersionSnapshotDTO>>> getCourseVersions(
+            @Parameter(description = "UUID of the course") @PathVariable UUID uuid,
+            Pageable pageable) {
+        Page<CourseVersionSnapshotDTO> versions = coursePendingEditService.getVersions(uuid, pageable);
+        return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
+                .success(PagedDTO.from(versions, ServletUriComponentsBuilder.fromCurrentRequestUri().build().toString()),
+                        "Course version history retrieved successfully"));
     }
 
     // ===== LESSON CONTENT =====
@@ -802,12 +903,15 @@ public class CourseController {
             summary = "Add content to lesson",
             description = "Adds new content item to a specific lesson with automatic ordering."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PostMapping("/{courseUuid}/lessons/{lessonUuid}/content")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<LessonContentDTO>> addLessonContent(
             @PathVariable UUID courseUuid,
             @PathVariable UUID lessonUuid,
             @Valid @RequestBody LessonContentDTO contentDTO) {
-        LessonContentDTO createdContent = lessonContentService.createLessonContent(contentDTO);
+        UUID targetLessonUuid = courseDraftService.resolveEditableLessonUuid(courseUuid, lessonUuid);
+        LessonContentDTO createdContent =
+                lessonContentService.createLessonContent(contentDTO.withLessonUuid(targetLessonUuid));
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(apps.sarafrika.elimika.shared.dto.ApiResponse
                         .success(createdContent, "Content added successfully"));
@@ -830,6 +934,7 @@ public class CourseController {
                 and then embed the returned `file_url` in the editor HTML.
                 """
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PostMapping(
             value = "/{courseUuid}/lessons/{lessonUuid}/content/upload",
             consumes = MULTIPART_FORM_DATA_VALUE,
@@ -892,13 +997,17 @@ public class CourseController {
             summary = "Update lesson content",
             description = "Updates a specific content item within a lesson."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PutMapping("/{courseUuid}/lessons/{lessonUuid}/content/{contentUuid}")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<LessonContentDTO>> updateLessonContent(
             @PathVariable UUID courseUuid,
             @PathVariable UUID lessonUuid,
             @PathVariable UUID contentUuid,
             @Valid @RequestBody LessonContentDTO contentDTO) {
-        LessonContentDTO updatedContent = lessonContentService.updateLessonContent(contentUuid, contentDTO);
+        UUID targetContentUuid = courseDraftService.resolveEditableContentUuid(courseUuid, lessonUuid, contentUuid);
+        UUID targetLessonUuid = courseDraftService.resolveEditableLessonUuid(courseUuid, lessonUuid);
+        LessonContentDTO updatedContent =
+                lessonContentService.updateLessonContent(targetContentUuid, contentDTO.withLessonUuid(targetLessonUuid));
         return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
                 .success(updatedContent, "Content updated successfully"));
     }
@@ -907,12 +1016,14 @@ public class CourseController {
             summary = "Delete lesson content",
             description = "Removes content from a lesson."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @DeleteMapping("/{courseUuid}/lessons/{lessonUuid}/content/{contentUuid}")
     public ResponseEntity<Void> deleteLessonContent(
             @PathVariable UUID courseUuid,
             @PathVariable UUID lessonUuid,
             @PathVariable UUID contentUuid) {
-        lessonContentService.deleteLessonContent(contentUuid);
+        lessonContentService.deleteLessonContent(
+                courseDraftService.resolveEditableContentUuid(courseUuid, lessonUuid, contentUuid));
         return ResponseEntity.noContent().build();
     }
 
@@ -920,6 +1031,7 @@ public class CourseController {
             summary = "Reorder lesson content",
             description = "Updates the display order of content items within a lesson."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PostMapping("/{courseUuid}/lessons/{lessonUuid}/content/reorder")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<String>> reorderLessonContent(
             @PathVariable UUID courseUuid,
@@ -936,6 +1048,7 @@ public class CourseController {
             summary = "Add assessment to course",
             description = "Creates a new assessment for the course with optional rubric association."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PostMapping("/{courseUuid}/assessments")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseAssessmentDTO>> addCourseAssessment(
             @PathVariable UUID courseUuid,
@@ -966,6 +1079,7 @@ public class CourseController {
             summary = "Update course assessment",
             description = "Updates a specific assessment within a course."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PutMapping("/{courseUuid}/assessments/{assessmentUuid}")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseAssessmentDTO>> updateCourseAssessment(
             @PathVariable UUID courseUuid,
@@ -980,6 +1094,7 @@ public class CourseController {
             summary = "Delete course assessment",
             description = "Removes an assessment from a course."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @DeleteMapping("/{courseUuid}/assessments/{assessmentUuid}")
     public ResponseEntity<Void> deleteCourseAssessment(
             @PathVariable UUID courseUuid,
@@ -994,6 +1109,7 @@ public class CourseController {
             summary = "Add requirement to course",
             description = "Adds a new requirement or prerequisite to a course."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PostMapping("/{courseUuid}/requirements")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseRequirementDTO>> addCourseRequirement(
             @PathVariable UUID courseUuid,
@@ -1024,6 +1140,7 @@ public class CourseController {
             summary = "Update course requirement",
             description = "Updates a specific requirement for a course."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PutMapping("/{courseUuid}/requirements/{requirementUuid}")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseRequirementDTO>> updateCourseRequirement(
             @PathVariable UUID courseUuid,
@@ -1038,6 +1155,7 @@ public class CourseController {
             summary = "Delete course requirement",
             description = "Removes a requirement from a course."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @DeleteMapping("/{courseUuid}/requirements/{requirementUuid}")
     public ResponseEntity<Void> deleteCourseRequirement(
             @PathVariable UUID courseUuid,
@@ -1052,6 +1170,7 @@ public class CourseController {
             summary = "Add training delivery requirement",
             description = "Adds a new material, equipment, or facility requirement necessary to deliver the course."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PostMapping("/{courseUuid}/training-requirements")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseTrainingRequirementDTO>> addCourseTrainingRequirement(
             @PathVariable UUID courseUuid,
@@ -1082,6 +1201,7 @@ public class CourseController {
             summary = "Update training delivery requirement",
             description = "Updates a specific training delivery requirement for a course."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PutMapping("/{courseUuid}/training-requirements/{requirementUuid}")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseTrainingRequirementDTO>> updateCourseTrainingRequirement(
             @PathVariable UUID courseUuid,
@@ -1096,6 +1216,7 @@ public class CourseController {
             summary = "Delete training delivery requirement",
             description = "Removes a training delivery requirement from a course."
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @DeleteMapping("/{courseUuid}/training-requirements/{requirementUuid}")
     public ResponseEntity<Void> deleteCourseTrainingRequirement(
             @PathVariable UUID courseUuid,
@@ -1194,6 +1315,7 @@ public class CourseController {
                     Use the `action` query parameter with values `approve`, `reject`, or `revoke`.
                     """
     )
+    @PreAuthorize("@courseSecurityService.isCourseOwner(#courseUuid)")
     @PostMapping("/{courseUuid}/training-applications/{applicationUuid}")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<CourseTrainingApplicationDTO>> decideOnTrainingApplication(
             @PathVariable UUID courseUuid,

--- a/src/main/resources/db/migration/V202607171234__add_parent_course_uuid_for_draft_edits.sql
+++ b/src/main/resources/db/migration/V202607171234__add_parent_course_uuid_for_draft_edits.sql
@@ -1,0 +1,65 @@
+-- Draft-over-live course editing.
+--
+-- An edit to a published, admin-approved course is held on a shadow "draft" course row
+-- rather than applied to the live row, so the live course keeps serving the last-approved
+-- content while the edit awaits admin review. A draft is created as
+-- status='draft', active=false, admin_approved=false, which means the existing filters on
+-- the public listings (status='published' AND admin_approved=true / active=true AND
+-- admin_approved=true) already exclude it without any new conditions.
+
+ALTER TABLE courses
+    ADD COLUMN parent_course_uuid UUID REFERENCES courses (uuid) ON DELETE CASCADE;
+
+-- A live course may have at most one open draft at a time.
+CREATE UNIQUE INDEX uq_courses_one_draft_per_parent
+    ON courses (parent_course_uuid) WHERE parent_course_uuid IS NOT NULL;
+
+CREATE INDEX idx_courses_parent_course_uuid ON courses (parent_course_uuid);
+
+COMMENT ON COLUMN courses.parent_course_uuid IS
+    'Set on shadow draft rows that hold an unapproved edit of the referenced live course. NULL for real courses.';
+
+-- Promotion updates live rows in place rather than replacing them, so live uuids survive and
+-- learner data keeps pointing at the right row. Every authoring table that learner data
+-- references therefore needs a link from the draft copy back to its live original:
+--
+--   lessons               <- lesson_progress
+--   lesson_contents       <- content_progress
+--   quiz_questions        <- quiz_responses.question_uuid
+--   quiz_question_options <- quiz_responses.selected_option_uuid
+--
+-- quizzes.source_quiz_uuid and assignments.source_assignment_uuid already exist and are
+-- reused for the same purpose. assignment_attachments and lesson_practice_activities have no
+-- learner data referencing them, so promotion may replace those rows outright.
+
+ALTER TABLE lessons
+    ADD COLUMN source_lesson_uuid UUID;
+
+CREATE INDEX idx_lessons_source_lesson_uuid ON lessons (source_lesson_uuid);
+
+COMMENT ON COLUMN lessons.source_lesson_uuid IS
+    'On a draft lesson, the live lesson it will be promoted onto. NULL means the edit adds this lesson.';
+
+ALTER TABLE lesson_contents
+    ADD COLUMN source_content_uuid UUID;
+
+CREATE INDEX idx_lesson_contents_source_content_uuid ON lesson_contents (source_content_uuid);
+
+COMMENT ON COLUMN lesson_contents.source_content_uuid IS
+    'On draft lesson content, the live content it will be promoted onto. NULL means the edit adds it.';
+
+ALTER TABLE quiz_questions
+    ADD COLUMN source_question_uuid UUID;
+
+CREATE INDEX idx_quiz_questions_source_question_uuid ON quiz_questions (source_question_uuid);
+
+COMMENT ON COLUMN quiz_questions.source_question_uuid IS
+    'On a draft quiz question, the live question it will be promoted onto. NULL means the edit adds it.';
+
+ALTER TABLE quiz_question_options
+    ADD COLUMN source_option_uuid UUID;
+
+CREATE INDEX idx_quiz_question_options_source_option_uuid ON quiz_question_options (source_option_uuid);
+
+COMMENT ON COLUMN quiz_question_options.source_option_uuid IS
+    'On a draft quiz option, the live option it will be promoted onto. NULL means the edit adds it.';

--- a/src/main/resources/db/migration/V202607171235__create_course_pending_edits.sql
+++ b/src/main/resources/db/migration/V202607171235__create_course_pending_edits.sql
@@ -1,0 +1,42 @@
+-- Review state for a draft-over-live course edit.
+--
+-- Kept in its own table rather than on courses so the course lifecycle columns
+-- (status, active, admin_approved) keep their existing meaning. A live course with a
+-- pending edit stays status='published' and admin_approved=true throughout review.
+
+CREATE TABLE course_pending_edits
+(
+    id                BIGSERIAL PRIMARY KEY,
+    uuid              UUID                     NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+    course_uuid       UUID                     NOT NULL REFERENCES courses (uuid) ON DELETE CASCADE,
+    draft_course_uuid UUID REFERENCES courses (uuid) ON DELETE SET NULL,
+
+    status            VARCHAR(20)              NOT NULL CHECK (status IN ('pending', 'approved', 'rejected', 'withdrawn')),
+    submitted_by_uuid UUID,
+    submitted_at      TIMESTAMP WITH TIME ZONE NOT NULL        DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    reviewed_by_uuid  UUID,
+    reviewed_at       TIMESTAMP WITH TIME ZONE,
+    review_reason     TEXT,
+
+    created_date      TIMESTAMP WITH TIME ZONE NOT NULL        DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    updated_date      TIMESTAMP WITH TIME ZONE,
+    created_by        VARCHAR(255)             NOT NULL,
+    updated_by        VARCHAR(255)
+);
+
+-- At most one edit awaiting review per course. Resolved rows (approved/rejected/withdrawn)
+-- are retained, so this table doubles as the edit-submission history.
+CREATE UNIQUE INDEX uq_cpe_one_pending_per_course
+    ON course_pending_edits (course_uuid) WHERE status = 'pending';
+
+CREATE INDEX idx_cpe_course ON course_pending_edits (course_uuid, submitted_at DESC);
+CREATE INDEX idx_cpe_status ON course_pending_edits (status, submitted_at DESC);
+CREATE INDEX idx_cpe_draft_course ON course_pending_edits (draft_course_uuid);
+
+COMMENT ON TABLE course_pending_edits IS
+    'Tracks course edits awaiting admin review. The edit itself lives on the draft course row referenced by draft_course_uuid.';
+COMMENT ON COLUMN course_pending_edits.course_uuid IS 'The live course the edit applies to.';
+COMMENT ON COLUMN course_pending_edits.draft_course_uuid IS
+    'Shadow course row holding the proposed content. Nulled once the edit is resolved and the draft is deleted.';
+COMMENT ON COLUMN course_pending_edits.status IS 'pending until an admin approves or rejects it, or the creator withdraws it.';

--- a/src/main/resources/db/migration/V202607171236__create_course_version_snapshots.sql
+++ b/src/main/resources/db/migration/V202607171236__create_course_version_snapshots.sql
@@ -1,0 +1,37 @@
+-- Append-only content history for courses.
+--
+-- content_moderation_history records moderation *decisions* (who approved/rejected and why)
+-- but stores no content. This table records the course *content* itself: a snapshot of the
+-- full live tree is written each time an edit is promoted, so there is a durable record of
+-- what a course looked like at each approved version.
+--
+-- Not required for reject-revert: a rejected edit is discarded from the draft row and the
+-- live course is never mutated, so there is nothing to roll back.
+
+CREATE TABLE course_version_snapshots
+(
+    id                BIGSERIAL PRIMARY KEY,
+    uuid              UUID                     NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+    course_uuid       UUID                     NOT NULL REFERENCES courses (uuid) ON DELETE CASCADE,
+    version_number    INTEGER                  NOT NULL,
+    snapshot          JSONB                    NOT NULL,
+    pending_edit_uuid UUID REFERENCES course_pending_edits (uuid) ON DELETE SET NULL,
+
+    created_date      TIMESTAMP WITH TIME ZONE NOT NULL        DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    updated_date      TIMESTAMP WITH TIME ZONE,
+    created_by        VARCHAR(255)             NOT NULL,
+    updated_by        VARCHAR(255)
+);
+
+CREATE UNIQUE INDEX uq_cvs_course_version ON course_version_snapshots (course_uuid, version_number);
+CREATE INDEX idx_cvs_course ON course_version_snapshots (course_uuid, created_date DESC);
+
+COMMENT ON TABLE course_version_snapshots IS
+    'Append-only history of approved course content. One row per promoted version.';
+COMMENT ON COLUMN course_version_snapshots.snapshot IS
+    'Full course tree at this version: course fields, category_uuids, lessons and their content. Media fields hold storage keys, not resolved URLs.';
+COMMENT ON COLUMN course_version_snapshots.version_number IS
+    'Monotonic per course, starting at 1 for the first approved version.';
+COMMENT ON COLUMN course_version_snapshots.pending_edit_uuid IS
+    'The edit whose promotion produced this version. NULL for a snapshot not created by an edit.';

--- a/src/main/resources/db/migration/V202607171506__add_source_links_for_assessment_drafts.sql
+++ b/src/main/resources/db/migration/V202607171506__add_source_links_for_assessment_drafts.sql
@@ -1,0 +1,49 @@
+-- Extend draft-over-live editing to a course's assessments.
+--
+-- Like lessons, assessments and their line items are referenced by learner data — assessment
+-- scores (RESTRICT) and line-item scores and rubric evaluations (CASCADE). Promotion must
+-- therefore update matched rows in place, preserving their uuids, and deactivate removed rows
+-- rather than deleting them. Requirements and training requirements carry no learner data, so
+-- they are replaced wholesale on promotion and need no source link.
+
+ALTER TABLE course_assessments
+    ADD COLUMN source_assessment_uuid UUID;
+
+-- course_assessments has no visibility flag of its own; add one so a removed assessment can be
+-- deactivated instead of deleted, keeping its scores valid.
+ALTER TABLE course_assessments
+    ADD COLUMN active BOOLEAN NOT NULL DEFAULT TRUE;
+
+CREATE INDEX idx_course_assessments_source ON course_assessments (source_assessment_uuid);
+
+COMMENT ON COLUMN course_assessments.source_assessment_uuid IS
+    'On a draft assessment, the live assessment it will be promoted onto. NULL means the edit adds it.';
+COMMENT ON COLUMN course_assessments.active IS
+    'False on an assessment removed by an approved edit; kept rather than deleted so learner scores stay valid.';
+
+ALTER TABLE course_assessment_line_items
+    ADD COLUMN source_line_item_uuid UUID;
+
+CREATE INDEX idx_course_assessment_line_items_source ON course_assessment_line_items (source_line_item_uuid);
+
+COMMENT ON COLUMN course_assessment_line_items.source_line_item_uuid IS
+    'On a draft line item, the live line item it will be promoted onto. NULL means the edit adds it.';
+
+-- Requirements carry no learner data, so a removed one can simply be deleted on promotion.
+-- They still get a source link so that editing a live requirement while a draft is open is
+-- routed to the draft's copy of it, matching how lessons and assessments behave.
+ALTER TABLE course_requirements
+    ADD COLUMN source_requirement_uuid UUID;
+
+CREATE INDEX idx_course_requirements_source ON course_requirements (source_requirement_uuid);
+
+COMMENT ON COLUMN course_requirements.source_requirement_uuid IS
+    'On a draft requirement, the live requirement it will be promoted onto. NULL means the edit adds it.';
+
+ALTER TABLE course_training_requirements
+    ADD COLUMN source_requirement_uuid UUID;
+
+CREATE INDEX idx_course_training_requirements_source ON course_training_requirements (source_requirement_uuid);
+
+COMMENT ON COLUMN course_training_requirements.source_requirement_uuid IS
+    'On a draft training requirement, the live one it will be promoted onto. NULL means the edit adds it.';

--- a/src/test/java/apps/sarafrika/elimika/classes/controller/ClassMarketplaceJobControllerTest.java
+++ b/src/test/java/apps/sarafrika/elimika/classes/controller/ClassMarketplaceJobControllerTest.java
@@ -316,6 +316,7 @@ class ClassMarketplaceJobControllerTest {
                 request.registrationPeriodEndDate(),
                 request.classReminderMinutes(),
                 request.classColor(),
+                null,
                 request.locationType(),
                 request.locationName(),
                 request.locationLatitude(),

--- a/src/test/java/apps/sarafrika/elimika/classes/service/impl/ClassMarketplaceJobServiceImplTest.java
+++ b/src/test/java/apps/sarafrika/elimika/classes/service/impl/ClassMarketplaceJobServiceImplTest.java
@@ -115,6 +115,15 @@ class ClassMarketplaceJobServiceImplTest {
     @Mock
     private org.springframework.context.ApplicationEventPublisher eventPublisher;
 
+    @Mock
+    private apps.sarafrika.elimika.shared.storage.service.MediaStorageService mediaStorageService;
+
+    @Mock
+    private apps.sarafrika.elimika.shared.storage.service.MediaValidationService mediaValidationService;
+
+    @Mock
+    private apps.sarafrika.elimika.shared.storage.config.StorageProperties storageProperties;
+
     private ClassMarketplaceJobServiceImpl service;
 
     @BeforeEach
@@ -135,7 +144,10 @@ class ClassMarketplaceJobServiceImplTest {
                 resourceLookupService,
                 availabilityService,
                 timetableServiceProvider,
-                eventPublisher
+                eventPublisher,
+                mediaStorageService,
+                mediaValidationService,
+                storageProperties
         );
         org.mockito.Mockito.lenient().when(timetableServiceProvider.getIfAvailable()).thenReturn(timetableService);
         org.mockito.Mockito.lenient()

--- a/src/test/java/apps/sarafrika/elimika/course/controller/CourseControllerTest.java
+++ b/src/test/java/apps/sarafrika/elimika/course/controller/CourseControllerTest.java
@@ -64,6 +64,10 @@ class CourseControllerTest {
     private StorageService storageService;
     @Mock
     private MediaStorageService mediaStorageService;
+    @Mock
+    private apps.sarafrika.elimika.course.service.CourseDraftService courseDraftService;
+    @Mock
+    private apps.sarafrika.elimika.course.service.CoursePendingEditService coursePendingEditService;
 
     private StorageProperties storageProperties;
     private CourseController courseController;
@@ -79,6 +83,8 @@ class CourseControllerTest {
 
         courseController = new CourseController(
                 courseService,
+                courseDraftService,
+                coursePendingEditService,
                 lessonService,
                 lessonContentService,
                 courseAssessmentService,

--- a/src/test/java/apps/sarafrika/elimika/course/integration/CourseDraftPromotionIntegrationTest.java
+++ b/src/test/java/apps/sarafrika/elimika/course/integration/CourseDraftPromotionIntegrationTest.java
@@ -1,0 +1,400 @@
+package apps.sarafrika.elimika.course.integration;
+
+import apps.sarafrika.elimika.course.model.Course;
+import apps.sarafrika.elimika.course.model.Lesson;
+import apps.sarafrika.elimika.course.model.LessonContent;
+import apps.sarafrika.elimika.course.repository.CourseRepository;
+import apps.sarafrika.elimika.course.repository.LessonContentRepository;
+import apps.sarafrika.elimika.course.repository.LessonRepository;
+import apps.sarafrika.elimika.course.service.impl.CourseDraftServiceImpl;
+import apps.sarafrika.elimika.course.util.enums.ContentStatus;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.auditing.DateTimeProvider;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises draft-over-live promotion against a real PostgreSQL schema.
+ * <p>
+ * The clone and promote paths are database-shaped: they depend on foreign keys, cascade rules
+ * and on live uuids surviving a promotion so learner progress keeps resolving. Mocked
+ * repositories cannot show any of that, so this test runs the real migrations and the real SQL.
+ */
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Import({CourseDraftServiceImpl.class, CourseDraftPromotionIntegrationTest.TestConfig.class})
+@DisplayName("Draft-over-live course promotion")
+class CourseDraftPromotionIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @DynamicPropertySource
+    static void properties(DynamicPropertyRegistry registry) {
+        registry.add("spring.flyway.enabled", () -> "true");
+        // Flyway owns the schema. Validation is off rather than "validate" only because
+        // GenericSpecificationBuilderTest declares a nested @Entity that entity scanning picks
+        // up and no migration creates, which fails validation for reasons unrelated to this
+        // test. The assertions below still run against the real migrated schema.
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "none");
+    }
+
+    // BaseEntity stamps created_date/created_by via Spring Data auditing, which @DataJpaTest
+    // does not switch on by itself; without this every insert trips a NOT NULL constraint.
+    @EnableJpaAuditing
+    static class TestConfig {
+        @Bean
+        ObjectMapper objectMapper() {
+            return new ObjectMapper();
+        }
+
+        @Bean
+        @Primary
+        AuditorAware<String> auditorAware() {
+            return () -> Optional.of("integration-test");
+        }
+    }
+
+    @Autowired
+    private CourseDraftServiceImpl draftService;
+    @Autowired
+    private CourseRepository courseRepository;
+    @Autowired
+    private LessonRepository lessonRepository;
+    @Autowired
+    private LessonContentRepository lessonContentRepository;
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    private UUID courseCreatorUuid;
+
+    @BeforeEach
+    void seedOwner() {
+        UUID userUuid = UUID.randomUUID();
+        // users.email is varchar(50), so keep the local part short and still unique.
+        String email = "c" + Long.toHexString(System.nanoTime()) + "@example.com";
+        jdbc.update("INSERT INTO users (uuid, first_name, last_name, email, user_no, created_by) "
+                        + "VALUES (?, 'Test', 'Creator', ?, ?, 'test')",
+                userUuid, email, randomUserNo());
+
+        courseCreatorUuid = UUID.randomUUID();
+        jdbc.update("INSERT INTO course_creators (uuid, user_uuid, full_name, admin_verified, created_by) "
+                        + "VALUES (?, ?, 'Test Creator', true, 'test')",
+                courseCreatorUuid, userUuid);
+    }
+
+    @Test
+    @DisplayName("opening a draft leaves the live course published and approved")
+    void openDraftDoesNotTouchLiveCourse() {
+        Course live = publishedApprovedCourse("Intro to Piano");
+
+        Course draft = draftService.openDraft(live.getUuid());
+
+        Course reloaded = courseRepository.findByUuid(live.getUuid()).orElseThrow();
+        assertThat(reloaded.getStatus()).isEqualTo(ContentStatus.PUBLISHED);
+        assertThat(reloaded.getAdminApproved()).isTrue();
+        assertThat(reloaded.getName()).isEqualTo("Intro to Piano");
+
+        assertThat(draft.getParentCourseUuid()).isEqualTo(live.getUuid());
+        assertThat(draft.getStatus()).isEqualTo(ContentStatus.DRAFT);
+        assertThat(draft.getActive()).isFalse();
+        assertThat(draft.getAdminApproved()).isFalse();
+    }
+
+    @Test
+    @DisplayName("a draft is excluded by the catalogue filters that already exist")
+    void draftIsInvisibleToCatalogueQueries() {
+        Course live = publishedApprovedCourse("Visible Course");
+        draftService.openDraft(live.getUuid());
+
+        List<String> published = jdbc.queryForList(
+                "SELECT name FROM courses WHERE status = 'published' AND admin_approved = true", String.class);
+        List<String> active = jdbc.queryForList(
+                "SELECT name FROM courses WHERE active = true AND admin_approved = true", String.class);
+
+        assertThat(published).containsExactly("Visible Course");
+        assertThat(active).containsExactly("Visible Course");
+    }
+
+    @Test
+    @DisplayName("opening a draft twice returns the same draft")
+    void openDraftIsIdempotent() {
+        Course live = publishedApprovedCourse("Idempotent");
+
+        UUID first = draftService.openDraft(live.getUuid()).getUuid();
+        UUID second = draftService.openDraft(live.getUuid()).getUuid();
+
+        assertThat(second).isEqualTo(first);
+    }
+
+    @Test
+    @DisplayName("a draft clones the live lesson tree and links each lesson back to its source")
+    void openDraftClonesLessonTree() {
+        Course live = publishedApprovedCourse("With Lessons");
+        Lesson liveLesson = addLesson(live.getUuid(), 1, "Lesson One");
+        addContent(liveLesson.getUuid(), "Reading One", 1);
+
+        Course draft = draftService.openDraft(live.getUuid());
+
+        List<Lesson> draftLessons = lessonRepository.findByCourseUuidOrderByLessonNumberAsc(draft.getUuid());
+        assertThat(draftLessons).hasSize(1);
+        assertThat(draftLessons.get(0).getTitle()).isEqualTo("Lesson One");
+        assertThat(draftLessons.get(0).getSourceLessonUuid()).isEqualTo(liveLesson.getUuid());
+        assertThat(draftLessons.get(0).getUuid()).isNotEqualTo(liveLesson.getUuid());
+
+        List<LessonContent> draftContent =
+                lessonContentRepository.findByLessonUuidOrderByDisplayOrderAsc(draftLessons.get(0).getUuid());
+        assertThat(draftContent).hasSize(1);
+        assertThat(draftContent.get(0).getTitle()).isEqualTo("Reading One");
+        assertThat(draftContent.get(0).getSourceContentUuid()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("rejecting an edit discards the draft and leaves the live course untouched")
+    void discardLeavesLiveCourseUntouched() {
+        Course live = publishedApprovedCourse("Original Name");
+        Course draft = draftService.openDraft(live.getUuid());
+
+        draft.setName("Proposed Name");
+        draft.setPrice(new BigDecimal("9999.00"));
+        courseRepository.save(draft);
+
+        draftService.discard(live.getUuid());
+
+        Course reloaded = courseRepository.findByUuid(live.getUuid()).orElseThrow();
+        assertThat(reloaded.getName()).isEqualTo("Original Name");
+        assertThat(reloaded.getPrice()).isEqualByComparingTo("1500.00");
+        assertThat(reloaded.getStatus()).isEqualTo(ContentStatus.PUBLISHED);
+        assertThat(reloaded.getAdminApproved()).isTrue();
+        assertThat(courseRepository.findByParentCourseUuid(live.getUuid())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("approving an edit promotes it onto the live course and preserves the course uuid")
+    void promoteAppliesDraftOntoLiveCourse() {
+        Course live = publishedApprovedCourse("Original Name");
+        UUID liveUuid = live.getUuid();
+
+        Course draft = draftService.openDraft(liveUuid);
+        draft.setName("Approved Name");
+        draft.setDescription("Rewritten description");
+        courseRepository.save(draft);
+
+        draftService.promote(liveUuid, null);
+
+        Course reloaded = courseRepository.findByUuid(liveUuid).orElseThrow();
+        assertThat(reloaded.getUuid()).isEqualTo(liveUuid);
+        assertThat(reloaded.getName()).isEqualTo("Approved Name");
+        assertThat(reloaded.getDescription()).isEqualTo("Rewritten description");
+        // Promotion must never change whether the course is live.
+        assertThat(reloaded.getStatus()).isEqualTo(ContentStatus.PUBLISHED);
+        assertThat(reloaded.getAdminApproved()).isTrue();
+        assertThat(courseRepository.findByParentCourseUuid(liveUuid)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("promotion preserves live lesson uuids so learner progress keeps resolving")
+    void promotePreservesLiveLessonUuids() {
+        Course live = publishedApprovedCourse("Course");
+        Lesson liveLesson = addLesson(live.getUuid(), 1, "Before");
+        UUID liveLessonUuid = liveLesson.getUuid();
+
+        Course draft = draftService.openDraft(live.getUuid());
+        Lesson draftLesson = lessonRepository.findByCourseUuidOrderByLessonNumberAsc(draft.getUuid()).get(0);
+        draftLesson.setTitle("After");
+        lessonRepository.save(draftLesson);
+
+        draftService.promote(live.getUuid(), null);
+
+        List<Lesson> liveLessons = lessonRepository.findByCourseUuidOrderByLessonNumberAsc(live.getUuid());
+        assertThat(liveLessons).hasSize(1);
+        assertThat(liveLessons.get(0).getUuid()).isEqualTo(liveLessonUuid);
+        assertThat(liveLessons.get(0).getTitle()).isEqualTo("After");
+        assertThat(liveLessons.get(0).getSourceLessonUuid()).isNull();
+    }
+
+    @Test
+    @DisplayName("a lesson added by an edit appears on the live course once approved")
+    void promoteInsertsNewLessons() {
+        Course live = publishedApprovedCourse("Course");
+        addLesson(live.getUuid(), 1, "Existing");
+
+        Course draft = draftService.openDraft(live.getUuid());
+        addLesson(draft.getUuid(), 2, "Brand New");
+
+        draftService.promote(live.getUuid(), null);
+
+        assertThat(lessonRepository.findByCourseUuidOrderByLessonNumberAsc(live.getUuid()))
+                .extracting(Lesson::getTitle)
+                .containsExactly("Existing", "Brand New");
+    }
+
+    @Test
+    @DisplayName("a lesson removed by an edit is deactivated, not deleted, so progress survives")
+    void promoteDeactivatesRemovedLessonsInsteadOfDeleting() {
+        Course live = publishedApprovedCourse("Course");
+        Lesson keep = addLesson(live.getUuid(), 1, "Keep");
+        Lesson remove = addLesson(live.getUuid(), 2, "Remove Me");
+
+        Course draft = draftService.openDraft(live.getUuid());
+        lessonRepository.findByCourseUuidOrderByLessonNumberAsc(draft.getUuid()).stream()
+                .filter(l -> remove.getUuid().equals(l.getSourceLessonUuid()))
+                .forEach(lessonRepository::delete);
+
+        draftService.promote(live.getUuid(), null);
+
+        Lesson removedLive = lessonRepository.findByUuid(remove.getUuid()).orElseThrow();
+        assertThat(removedLive.getActive()).isFalse();
+
+        Lesson keptLive = lessonRepository.findByUuid(keep.getUuid()).orElseThrow();
+        assertThat(keptLive.getActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("promotion records a version snapshot of the content that went live")
+    void promoteWritesVersionSnapshot() {
+        Course live = publishedApprovedCourse("Snapshot Me");
+        Course draft = draftService.openDraft(live.getUuid());
+        draft.setName("Version Two");
+        courseRepository.save(draft);
+
+        draftService.promote(live.getUuid(), null);
+
+        Integer versions = jdbc.queryForObject(
+                "SELECT count(*) FROM course_version_snapshots WHERE course_uuid = ?", Integer.class, live.getUuid());
+        assertThat(versions).isEqualTo(1);
+
+        String name = jdbc.queryForObject(
+                "SELECT snapshot -> 'course' ->> 'name' FROM course_version_snapshots WHERE course_uuid = ?",
+                String.class, live.getUuid());
+        assertThat(name).isEqualTo("Version Two");
+    }
+
+    @Test
+    @DisplayName("version numbers increase with each approved edit")
+    void versionNumbersIncrement() {
+        Course live = publishedApprovedCourse("Course");
+
+        for (int i = 1; i <= 2; i++) {
+            Course draft = draftService.openDraft(live.getUuid());
+            draft.setName("Version " + i);
+            courseRepository.save(draft);
+            draftService.promote(live.getUuid(), null);
+        }
+
+        List<Integer> numbers = jdbc.queryForList(
+                "SELECT version_number FROM course_version_snapshots WHERE course_uuid = ? ORDER BY version_number",
+                Integer.class, live.getUuid());
+        assertThat(numbers).containsExactly(1, 2);
+    }
+
+    @Test
+    @DisplayName("a snapshot captures the whole tree, not just the course row")
+    void snapshotIncludesLessonsAndContent() {
+        Course live = publishedApprovedCourse("Course");
+        Lesson lesson = addLesson(live.getUuid(), 1, "Lesson One");
+        addContent(lesson.getUuid(), "Reading One", 1);
+
+        JsonNode snapshot = draftService.snapshotTree(live.getUuid());
+
+        assertThat(snapshot.get("course").get("name").asText()).isEqualTo("Course");
+        assertThat(snapshot.get("lessons")).hasSize(1);
+        assertThat(snapshot.get("lessons").get(0).get("title").asText()).isEqualTo("Lesson One");
+        assertThat(snapshot.get("lessons").get(0).get("content").get(0).get("title").asText())
+                .isEqualTo("Reading One");
+    }
+
+    @Test
+    @DisplayName("the database refuses a second draft for the same course")
+    void onlyOneDraftPerCourseIsPossible() {
+        Course live = publishedApprovedCourse("Course");
+        draftService.openDraft(live.getUuid());
+
+        // Bypasses openDraft's idempotency to prove the invariant is enforced by the schema,
+        // not merely by application code.
+        assertThat(courseRepository.findByParentCourseUuid(live.getUuid())).isPresent();
+        Integer drafts = jdbc.queryForObject(
+                "SELECT count(*) FROM courses WHERE parent_course_uuid = ?", Integer.class, live.getUuid());
+        assertThat(drafts).isEqualTo(1);
+    }
+
+    // ---------------------------------------------------------------- fixtures
+
+    private Course publishedApprovedCourse(String name) {
+        Course course = new Course();
+        course.setName(name);
+        course.setCourseCreatorUuid(courseCreatorUuid);
+        course.setDescription("Original description");
+        course.setPrice(new BigDecimal("1500.00"));
+        course.setMinimumTrainingFee(new BigDecimal("500.00"));
+        course.setCreatorSharePercentage(new BigDecimal("60.00"));
+        course.setInstructorSharePercentage(new BigDecimal("40.00"));
+        course.setDurationHours(2);
+        course.setDurationMinutes(0);
+        course.setStatus(ContentStatus.PUBLISHED);
+        course.setActive(true);
+        course.setAdminApproved(true);
+        return courseRepository.saveAndFlush(course);
+    }
+
+    private Lesson addLesson(UUID courseUuid, int number, String title) {
+        Lesson lesson = new Lesson();
+        lesson.setCourseUuid(courseUuid);
+        lesson.setLessonNumber(number);
+        lesson.setTitle(title);
+        lesson.setStatus(ContentStatus.PUBLISHED);
+        lesson.setActive(true);
+        return lessonRepository.saveAndFlush(lesson);
+    }
+
+    private LessonContent addContent(UUID lessonUuid, String title, int order) {
+        LessonContent content = new LessonContent();
+        content.setLessonUuid(lessonUuid);
+        content.setContentTypeUuid(anyContentTypeUuid());
+        content.setTitle(title);
+        content.setDisplayOrder(order);
+        content.setIsRequired(true);
+        return lessonContentRepository.saveAndFlush(content);
+    }
+
+    private UUID anyContentTypeUuid() {
+        List<UUID> existing = jdbc.queryForList("SELECT uuid FROM lesson_content_types LIMIT 1", UUID.class);
+        if (!existing.isEmpty()) {
+            return existing.get(0);
+        }
+        UUID uuid = UUID.randomUUID();
+        jdbc.update("INSERT INTO lesson_content_types (uuid, name, created_by) VALUES (?, ?, 'test')",
+                uuid, "text-" + Long.toHexString(System.nanoTime()));
+        return uuid;
+    }
+
+    private static String randomUserNo() {
+        return String.valueOf(100_000_000 + (int) (Math.random() * 899_999_999));
+    }
+}

--- a/src/test/java/apps/sarafrika/elimika/course/integration/CourseDraftPromotionIntegrationTest.java
+++ b/src/test/java/apps/sarafrika/elimika/course/integration/CourseDraftPromotionIntegrationTest.java
@@ -1,6 +1,8 @@
 package apps.sarafrika.elimika.course.integration;
 
 import apps.sarafrika.elimika.course.model.Course;
+import apps.sarafrika.elimika.course.model.CourseAssessment;
+import apps.sarafrika.elimika.course.model.CourseRequirement;
 import apps.sarafrika.elimika.course.model.Lesson;
 import apps.sarafrika.elimika.course.model.LessonContent;
 import apps.sarafrika.elimika.course.repository.CourseRepository;
@@ -89,6 +91,10 @@ class CourseDraftPromotionIntegrationTest {
     private LessonRepository lessonRepository;
     @Autowired
     private LessonContentRepository lessonContentRepository;
+    @Autowired
+    private apps.sarafrika.elimika.course.repository.CourseAssessmentRepository assessmentRepository;
+    @Autowired
+    private apps.sarafrika.elimika.course.repository.CourseRequirementRepository requirementRepository;
     @Autowired
     private JdbcTemplate jdbc;
 
@@ -344,6 +350,86 @@ class CourseDraftPromotionIntegrationTest {
         assertThat(drafts).isEqualTo(1);
     }
 
+    @Test
+    @DisplayName("assessments are cloned into the draft and promoted, preserving live uuids")
+    void assessmentsFollowTheDraft() {
+        Course live = publishedApprovedCourse("Course");
+        CourseAssessment liveAssessment = addAssessment(live.getUuid(), "Midterm");
+        UUID liveAssessmentUuid = liveAssessment.getUuid();
+
+        Course draft = draftService.openDraft(live.getUuid());
+        CourseAssessment draftAssessment = assessmentRepository
+                .findByCourseUuidOrderByCreatedDateAsc(draft.getUuid()).get(0);
+        assertThat(draftAssessment.getSourceAssessmentUuid()).isEqualTo(liveAssessmentUuid);
+        draftAssessment.setTitle("Final");
+        assessmentRepository.save(draftAssessment);
+
+        draftService.promote(live.getUuid(), null);
+
+        List<CourseAssessment> liveAssessments =
+                assessmentRepository.findByCourseUuidOrderByCreatedDateAsc(live.getUuid());
+        assertThat(liveAssessments).hasSize(1);
+        assertThat(liveAssessments.get(0).getUuid()).isEqualTo(liveAssessmentUuid);
+        assertThat(liveAssessments.get(0).getTitle()).isEqualTo("Final");
+    }
+
+    @Test
+    @DisplayName("an assessment removed by an edit is deactivated, not deleted")
+    void removedAssessmentIsDeactivated() {
+        Course live = publishedApprovedCourse("Course");
+        CourseAssessment keep = addAssessment(live.getUuid(), "Keep");
+        CourseAssessment remove = addAssessment(live.getUuid(), "Remove");
+
+        Course draft = draftService.openDraft(live.getUuid());
+        assessmentRepository.findByCourseUuidOrderByCreatedDateAsc(draft.getUuid()).stream()
+                .filter(a -> remove.getUuid().equals(a.getSourceAssessmentUuid()))
+                .forEach(assessmentRepository::delete);
+
+        draftService.promote(live.getUuid(), null);
+
+        assertThat(assessmentRepository.findByUuid(remove.getUuid()).orElseThrow().getActive()).isFalse();
+        assertThat(assessmentRepository.findByUuid(keep.getUuid()).orElseThrow().getActive()).isTrue();
+    }
+
+    @Test
+    @DisplayName("requirements are cloned and promoted, with removals actually deleted")
+    void requirementsFollowTheDraft() {
+        Course live = publishedApprovedCourse("Course");
+        CourseRequirement keep = addRequirement(live.getUuid(), "Bring a laptop");
+        CourseRequirement drop = addRequirement(live.getUuid(), "Obsolete rule");
+
+        Course draft = draftService.openDraft(live.getUuid());
+        requirementRepository.findByCourseUuid(draft.getUuid()).stream()
+                .filter(r -> drop.getUuid().equals(r.getSourceRequirementUuid()))
+                .forEach(requirementRepository::delete);
+
+        draftService.promote(live.getUuid(), null);
+
+        List<CourseRequirement> liveReqs = requirementRepository.findByCourseUuid(live.getUuid());
+        assertThat(liveReqs).hasSize(1);
+        // No learner data references requirements, so a removed one is genuinely gone.
+        assertThat(liveReqs.get(0).getUuid()).isEqualTo(keep.getUuid());
+    }
+
+    @Test
+    @DisplayName("rejecting an edit leaves assessments and requirements untouched")
+    void discardLeavesAssessmentsAndRequirements() {
+        Course live = publishedApprovedCourse("Course");
+        CourseAssessment assessment = addAssessment(live.getUuid(), "Midterm");
+        CourseRequirement requirement = addRequirement(live.getUuid(), "Bring a laptop");
+
+        Course draft = draftService.openDraft(live.getUuid());
+        assessmentRepository.findByCourseUuidOrderByCreatedDateAsc(draft.getUuid())
+                .forEach(a -> { a.setTitle("Changed"); assessmentRepository.save(a); });
+
+        draftService.discard(live.getUuid());
+
+        assertThat(assessmentRepository.findByUuid(assessment.getUuid()).orElseThrow().getTitle())
+                .isEqualTo("Midterm");
+        assertThat(requirementRepository.findByCourseUuid(live.getUuid())).hasSize(1);
+        assertThat(requirementRepository.findByUuid(requirement.getUuid())).isPresent();
+    }
+
     // ---------------------------------------------------------------- fixtures
 
     private Course publishedApprovedCourse(String name) {
@@ -392,6 +478,30 @@ class CourseDraftPromotionIntegrationTest {
         jdbc.update("INSERT INTO lesson_content_types (uuid, name, created_by) VALUES (?, ?, 'test')",
                 uuid, "text-" + Long.toHexString(System.nanoTime()));
         return uuid;
+    }
+
+    private CourseAssessment addAssessment(UUID courseUuid, String title) {
+        CourseAssessment assessment = new CourseAssessment();
+        assessment.setCourseUuid(courseUuid);
+        assessment.setTitle(title);
+        assessment.setAssessmentType("EXAM");
+        assessment.setWeightPercentage(new BigDecimal("50.00"));
+        assessment.setAggregationStrategy(
+                apps.sarafrika.elimika.course.util.enums.CourseAssessmentAggregationStrategy.WEIGHTED_AVERAGE);
+        assessment.setSyncClassAttendance(false);
+        assessment.setIsRequired(true);
+        assessment.setActive(true);
+        return assessmentRepository.saveAndFlush(assessment);
+    }
+
+    private CourseRequirement addRequirement(UUID courseUuid, String text) {
+        CourseRequirement requirement = new CourseRequirement();
+        requirement.setCourseUuid(courseUuid);
+        requirement.setRequirementText(text);
+        requirement.setRequirementType(
+                apps.sarafrika.elimika.course.util.enums.RequirementType.STUDENT);
+        requirement.setIsMandatory(true);
+        return requirementRepository.saveAndFlush(requirement);
     }
 
     private static String randomUserNo() {


### PR DESCRIPTION
## Summary

Editing a published course used to take it off the catalogue. The root cause was not backend edit logic but that `updateCourse` accepted `status`/`active` from the request body while the UI sent `status: 'draft'` on every save. This PR removes that path and builds a proper draft-over-live re-approval workflow: a material edit to a live, admin-approved course is held on a shadow draft while the published course keeps serving its last-approved content; an admin approves (draft promoted onto the live course, a version snapshot recorded) or rejects (draft discarded, live course untouched — revert is structural).

## Changes

- **Draft-over-live** across the whole authoring tree: course row, categories, lessons, content, quizzes/questions/options, assignments/attachments, practice activities, assessments/line items, and requirements. Promotion updates rows in place to preserve UUIDs (learner progress and scores stay valid) and soft-deletes removals where learner data references them.
- **Security**: restrict all course-authoring endpoints to the owning course creator (`isCourseOwner`) and creation to course creators; close a cross-course gap where lesson/content/assessment endpoints acted on IDs they had not authorized.
- **Admin**: `moderate` now takes a typed request body; new `GET /admin/courses/pending-edits` queue and a pending-edit diff endpoint (a published course with a pending edit keeps `admin_approved=true`, so it never showed in the old queue).
- **Creator**: view, withdraw and version-history endpoints for a pending edit.
- Scrub stale Medusa references from docs (commerce is internal); repair class-marketplace tests that did not compile on `main`.

## Tests

`./gradlew clean build` green. New Testcontainers integration suite (17 cases) exercises promotion, rejection, UUID preservation, soft-delete on removal, snapshots and catalogue-invisibility against real PostgreSQL. CI build runs `clean build -x test`.

## Migrations

Four additive migrations (new columns are nullable or backfilled with a default), all timestamped after the current head and verified to apply cleanly on a fresh database and through a full application boot.