### PR TITLE
feat: organisation dashboard analytics endpoints + venue attributes

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/tenancy/controller/OrganisationController.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/controller/OrganisationController.java
@@ -235,6 +235,8 @@ class OrganisationController {
                 trainingBranchDTO.pocEmail(),
                 trainingBranchDTO.pocTelephone(),
                 trainingBranchDTO.active(),
+                trainingBranchDTO.capacity(),
+                trainingBranchDTO.venueType(),
                 null, null
         );
         TrainingBranchDTO created = trainingBranchService.createTrainingBranch(branchWithOrgUuid);

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/TrainingBranchDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/TrainingBranchDTO.java
@@ -126,6 +126,26 @@ public record TrainingBranchDTO(
         boolean active,
 
         @Schema(
+                description = "**[OPTIONAL]** Seating/attendee capacity of the venue.",
+                example = "30",
+                nullable = true,
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        @JsonProperty("capacity")
+        Integer capacity,
+
+        @Schema(
+                description = "**[OPTIONAL]** Free-form venue/room type (e.g. Lab, Workshop, Auditorium).",
+                example = "Lab",
+                maxLength = 50,
+                nullable = true,
+                requiredMode = Schema.RequiredMode.NOT_REQUIRED
+        )
+        @Size(max = 50, message = "Venue type cannot exceed 50 characters")
+        @JsonProperty("venue_type")
+        String venueType,
+
+        @Schema(
                 description = "**[READ-ONLY]** Timestamp when the training branch was first created. Automatically set by the system and cannot be modified.",
                 example = "2024-01-01T09:00:00Z",
                 format = "date-time",

--- a/src/main/java/apps/sarafrika/elimika/tenancy/entity/TrainingBranch.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/entity/TrainingBranch.java
@@ -36,6 +36,12 @@ public class TrainingBranch extends BaseEntity {
     @Column(name = "poc_telephone")
     private String pocTelephone;
 
+    @Column(name = "capacity")
+    private Integer capacity;
+
+    @Column(name = "venue_type")
+    private String venueType;
+
     @Column(name = "active")
     private boolean active = true;
 

--- a/src/main/java/apps/sarafrika/elimika/tenancy/factory/TrainingBranchFactory.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/factory/TrainingBranchFactory.java
@@ -18,6 +18,8 @@ public class TrainingBranchFactory {
                 trainingBranch.getPocEmail(),
                 trainingBranch.getPocTelephone(),
                 trainingBranch.isActive(),
+                trainingBranch.getCapacity(),
+                trainingBranch.getVenueType(),
                 trainingBranch.getCreatedDate(),
                 trainingBranch.getLastModifiedDate()
         );
@@ -33,6 +35,8 @@ public class TrainingBranchFactory {
         trainingBranch.setPocEmail(trainingBranchDTO.pocEmail());
         trainingBranch.setPocTelephone(trainingBranchDTO.pocTelephone());
         trainingBranch.setActive(trainingBranchDTO.active());
+        trainingBranch.setCapacity(trainingBranchDTO.capacity());
+        trainingBranch.setVenueType(trainingBranchDTO.venueType());
         return trainingBranch;
     }
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/controller/EnrollmentController.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/controller/EnrollmentController.java
@@ -2,6 +2,7 @@ package apps.sarafrika.elimika.timetabling.controller;
 
 import apps.sarafrika.elimika.shared.dto.ApiResponse;
 import apps.sarafrika.elimika.shared.dto.PagedDTO;
+import apps.sarafrika.elimika.timetabling.spi.EnrolmentTrendPointDTO;
 import apps.sarafrika.elimika.timetabling.spi.EnrollmentDTO;
 import apps.sarafrika.elimika.timetabling.spi.EnrollmentRequestDTO;
 import apps.sarafrika.elimika.timetabling.spi.StudentCourseEnrollmentSummaryDTO;
@@ -265,5 +266,24 @@ public class EnrollmentController {
         boolean hasCapacity = timetableService.hasCapacityForEnrollment(instanceUuid);
         return ResponseEntity.ok(ApiResponse.success(hasCapacity,
             hasCapacity ? "Capacity available" : "Instance is at full capacity"));
+    }
+
+    @Operation(
+            summary = "Get organisation enrolment trends",
+            description = "Monthly enrolment counts across all classes owned by the organisation, oldest month first."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Enrolment trends retrieved successfully")
+    @GetMapping("/organisations/{organisationUuid}/enrolment-trends")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<List<EnrolmentTrendPointDTO>>> getEnrolmentTrends(
+            @Parameter(description = "UUID of the organisation to scope the trend to")
+            @PathVariable UUID organisationUuid,
+            @Parameter(description = "Number of months to include (inclusive of the current month)")
+            @RequestParam(defaultValue = "6") int months) {
+        log.debug("REST request for enrolment trends of organisation {} over {} months", organisationUuid, months);
+
+        List<EnrolmentTrendPointDTO> trends =
+                timetableService.getEnrolmentTrendsForOrganisation(organisationUuid, months);
+        return ResponseEntity.ok(ApiResponse.success(trends, "Enrolment trends retrieved successfully"));
     }
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/controller/EnrollmentController.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/controller/EnrollmentController.java
@@ -4,6 +4,8 @@ import apps.sarafrika.elimika.shared.dto.ApiResponse;
 import apps.sarafrika.elimika.shared.dto.PagedDTO;
 import apps.sarafrika.elimika.timetabling.spi.EnrolmentTrendPointDTO;
 import apps.sarafrika.elimika.timetabling.spi.TodayGrowthPointDTO;
+import apps.sarafrika.elimika.timetabling.spi.ClassEnrolmentCountDTO;
+import apps.sarafrika.elimika.timetabling.spi.StudentEnrolmentSummaryDTO;
 import apps.sarafrika.elimika.timetabling.spi.EnrollmentDTO;
 import apps.sarafrika.elimika.timetabling.spi.EnrollmentRequestDTO;
 import apps.sarafrika.elimika.timetabling.spi.StudentCourseEnrollmentSummaryDTO;
@@ -302,5 +304,39 @@ public class EnrollmentController {
 
         List<TodayGrowthPointDTO> growth = timetableService.getTodayGrowthForOrganisation(organisationUuid);
         return ResponseEntity.ok(ApiResponse.success(growth, "Today's growth retrieved successfully"));
+    }
+
+    @Operation(
+            summary = "Get per-class enrolment counts for an organisation",
+            description = "Distinct active-enrolment counts for each class definition the organisation owns."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Class enrolment counts retrieved successfully")
+    @GetMapping("/organisations/{organisationUuid}/class-enrolment-counts")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<List<ClassEnrolmentCountDTO>>> getClassEnrolmentCounts(
+            @Parameter(description = "UUID of the organisation to scope to")
+            @PathVariable UUID organisationUuid) {
+        log.debug("REST request for per-class enrolment counts of organisation {}", organisationUuid);
+
+        List<ClassEnrolmentCountDTO> counts =
+                timetableService.getClassEnrolmentCountsForOrganisation(organisationUuid);
+        return ResponseEntity.ok(ApiResponse.success(counts, "Class enrolment counts retrieved successfully"));
+    }
+
+    @Operation(
+            summary = "Get per-student enrolment summaries for an organisation",
+            description = "Per-student total and attended (completed) enrolment counts across the organisation's classes."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Student enrolment summaries retrieved successfully")
+    @GetMapping("/organisations/{organisationUuid}/student-summaries")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<List<StudentEnrolmentSummaryDTO>>> getStudentSummaries(
+            @Parameter(description = "UUID of the organisation to scope to")
+            @PathVariable UUID organisationUuid) {
+        log.debug("REST request for per-student enrolment summaries of organisation {}", organisationUuid);
+
+        List<StudentEnrolmentSummaryDTO> summaries =
+                timetableService.getStudentEnrolmentSummariesForOrganisation(organisationUuid);
+        return ResponseEntity.ok(ApiResponse.success(summaries, "Student enrolment summaries retrieved successfully"));
     }
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/controller/EnrollmentController.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/controller/EnrollmentController.java
@@ -3,6 +3,7 @@ package apps.sarafrika.elimika.timetabling.controller;
 import apps.sarafrika.elimika.shared.dto.ApiResponse;
 import apps.sarafrika.elimika.shared.dto.PagedDTO;
 import apps.sarafrika.elimika.timetabling.spi.EnrolmentTrendPointDTO;
+import apps.sarafrika.elimika.timetabling.spi.TodayGrowthPointDTO;
 import apps.sarafrika.elimika.timetabling.spi.EnrollmentDTO;
 import apps.sarafrika.elimika.timetabling.spi.EnrollmentRequestDTO;
 import apps.sarafrika.elimika.timetabling.spi.StudentCourseEnrollmentSummaryDTO;
@@ -285,5 +286,21 @@ public class EnrollmentController {
         List<EnrolmentTrendPointDTO> trends =
                 timetableService.getEnrolmentTrendsForOrganisation(organisationUuid, months);
         return ResponseEntity.ok(ApiResponse.success(trends, "Enrolment trends retrieved successfully"));
+    }
+
+    @Operation(
+            summary = "Get organisation today's-growth",
+            description = "Hourly enrolment counts for the current day across all classes owned by the organisation."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Today's growth retrieved successfully")
+    @GetMapping("/organisations/{organisationUuid}/today-growth")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse<List<TodayGrowthPointDTO>>> getTodayGrowth(
+            @Parameter(description = "UUID of the organisation to scope to")
+            @PathVariable UUID organisationUuid) {
+        log.debug("REST request for today's growth of organisation {}", organisationUuid);
+
+        List<TodayGrowthPointDTO> growth = timetableService.getTodayGrowthForOrganisation(organisationUuid);
+        return ResponseEntity.ok(ApiResponse.success(growth, "Today's growth retrieved successfully"));
     }
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/repository/EnrollmentRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/repository/EnrollmentRepository.java
@@ -171,4 +171,20 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long>, J
     long countByStatusAndAttendanceMarkedAtBetween(EnrollmentStatus status, LocalDateTime start, LocalDateTime end);
 
     long countByStatusAndCreatedDateBetween(EnrollmentStatus status, LocalDateTime start, LocalDateTime end);
+
+    /**
+     * Monthly enrolment counts for classes owned by the given organisation, from a
+     * cut-off date onward. Returns rows of {@code [month (YYYY-MM string), total (long)]}.
+     */
+    @Query(value = "SELECT to_char(ce.created_date, 'YYYY-MM') AS month, COUNT(*) AS total " +
+                   "FROM class_enrollments ce " +
+                   "JOIN scheduled_instances si ON ce.scheduled_instance_uuid = si.uuid " +
+                   "JOIN class_definitions cd ON si.class_definition_uuid = cd.uuid " +
+                   "WHERE cd.organisation_uuid = :organisationUuid " +
+                   "AND ce.created_date >= :since " +
+                   "GROUP BY 1 " +
+                   "ORDER BY 1",
+           nativeQuery = true)
+    List<Object[]> findEnrolmentTrendsForOrganisation(@Param("organisationUuid") UUID organisationUuid,
+                                                      @Param("since") LocalDateTime since);
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/repository/EnrollmentRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/repository/EnrollmentRepository.java
@@ -187,4 +187,20 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long>, J
            nativeQuery = true)
     List<Object[]> findEnrolmentTrendsForOrganisation(@Param("organisationUuid") UUID organisationUuid,
                                                       @Param("since") LocalDateTime since);
+
+    /**
+     * Hourly enrolment counts for the current day for classes owned by the given
+     * organisation. Returns rows of {@code [hour (HH:00 string), total (long)]}.
+     */
+    @Query(value = "SELECT to_char(ce.created_date, 'HH24:00') AS hour, COUNT(*) AS total " +
+                   "FROM class_enrollments ce " +
+                   "JOIN scheduled_instances si ON ce.scheduled_instance_uuid = si.uuid " +
+                   "JOIN class_definitions cd ON si.class_definition_uuid = cd.uuid " +
+                   "WHERE cd.organisation_uuid = :organisationUuid " +
+                   "AND ce.created_date >= :startOfDay " +
+                   "GROUP BY 1 " +
+                   "ORDER BY 1",
+           nativeQuery = true)
+    List<Object[]> findEnrolmentsByHourTodayForOrganisation(@Param("organisationUuid") UUID organisationUuid,
+                                                            @Param("startOfDay") LocalDateTime startOfDay);
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/repository/EnrollmentRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/repository/EnrollmentRepository.java
@@ -203,4 +203,35 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long>, J
            nativeQuery = true)
     List<Object[]> findEnrolmentsByHourTodayForOrganisation(@Param("organisationUuid") UUID organisationUuid,
                                                             @Param("startOfDay") LocalDateTime startOfDay);
+
+    /**
+     * Distinct active-enrolment counts per class definition for an organisation.
+     * Returns rows of {@code [class_definition_uuid (UUID), enrolled (long)]}.
+     */
+    @Query(value = "SELECT si.class_definition_uuid AS class_uuid, COUNT(DISTINCT ce.student_uuid) AS enrolled " +
+                   "FROM class_enrollments ce " +
+                   "JOIN scheduled_instances si ON ce.scheduled_instance_uuid = si.uuid " +
+                   "JOIN class_definitions cd ON si.class_definition_uuid = cd.uuid " +
+                   "WHERE cd.organisation_uuid = :organisationUuid " +
+                   "AND ce.status NOT IN ('CANCELLED', 'WAITLISTED') " +
+                   "GROUP BY si.class_definition_uuid",
+           nativeQuery = true)
+    List<Object[]> findClassEnrolmentCountsForOrganisation(@Param("organisationUuid") UUID organisationUuid);
+
+    /**
+     * Per-student enrolment/attendance summary for an organisation. Returns rows of
+     * {@code [student_uuid (UUID), total (long), completed (long)]} where total
+     * excludes cancelled/waitlisted and completed counts ATTENDED enrolments.
+     */
+    @Query(value = "SELECT ce.student_uuid AS student_uuid, " +
+                   "COUNT(*) AS total, " +
+                   "COUNT(*) FILTER (WHERE ce.status = 'ATTENDED') AS completed " +
+                   "FROM class_enrollments ce " +
+                   "JOIN scheduled_instances si ON ce.scheduled_instance_uuid = si.uuid " +
+                   "JOIN class_definitions cd ON si.class_definition_uuid = cd.uuid " +
+                   "WHERE cd.organisation_uuid = :organisationUuid " +
+                   "AND ce.status NOT IN ('CANCELLED', 'WAITLISTED') " +
+                   "GROUP BY ce.student_uuid",
+           nativeQuery = true)
+    List<Object[]> findStudentEnrolmentSummariesForOrganisation(@Param("organisationUuid") UUID organisationUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImpl.java
@@ -38,6 +38,7 @@ import apps.sarafrika.elimika.timetabling.repository.ScheduledInstanceRepository
 import apps.sarafrika.elimika.timetabling.spi.TimetableService;
 import apps.sarafrika.elimika.timetabling.spi.EnrollmentStatus;
 import apps.sarafrika.elimika.timetabling.spi.EnrolmentTrendPointDTO;
+import apps.sarafrika.elimika.timetabling.spi.TodayGrowthPointDTO;
 import apps.sarafrika.elimika.timetabling.spi.SchedulingStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -1428,6 +1429,15 @@ public class TimetableServiceImpl implements TimetableService {
                 .atStartOfDay();
         return enrollmentRepository.findEnrolmentTrendsForOrganisation(organisationUuid, since).stream()
                 .map(row -> new EnrolmentTrendPointDTO((String) row[0], ((Number) row[1]).longValue()))
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<TodayGrowthPointDTO> getTodayGrowthForOrganisation(UUID organisationUuid) {
+        java.time.LocalDateTime startOfDay = java.time.LocalDate.now().atStartOfDay();
+        return enrollmentRepository.findEnrolmentsByHourTodayForOrganisation(organisationUuid, startOfDay).stream()
+                .map(row -> new TodayGrowthPointDTO((String) row[0], ((Number) row[1]).longValue()))
                 .toList();
     }
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImpl.java
@@ -39,6 +39,8 @@ import apps.sarafrika.elimika.timetabling.spi.TimetableService;
 import apps.sarafrika.elimika.timetabling.spi.EnrollmentStatus;
 import apps.sarafrika.elimika.timetabling.spi.EnrolmentTrendPointDTO;
 import apps.sarafrika.elimika.timetabling.spi.TodayGrowthPointDTO;
+import apps.sarafrika.elimika.timetabling.spi.ClassEnrolmentCountDTO;
+import apps.sarafrika.elimika.timetabling.spi.StudentEnrolmentSummaryDTO;
 import apps.sarafrika.elimika.timetabling.spi.SchedulingStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -1438,6 +1440,23 @@ public class TimetableServiceImpl implements TimetableService {
         java.time.LocalDateTime startOfDay = java.time.LocalDate.now().atStartOfDay();
         return enrollmentRepository.findEnrolmentsByHourTodayForOrganisation(organisationUuid, startOfDay).stream()
                 .map(row -> new TodayGrowthPointDTO((String) row[0], ((Number) row[1]).longValue()))
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ClassEnrolmentCountDTO> getClassEnrolmentCountsForOrganisation(UUID organisationUuid) {
+        return enrollmentRepository.findClassEnrolmentCountsForOrganisation(organisationUuid).stream()
+                .map(row -> new ClassEnrolmentCountDTO((UUID) row[0], ((Number) row[1]).longValue()))
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<StudentEnrolmentSummaryDTO> getStudentEnrolmentSummariesForOrganisation(UUID organisationUuid) {
+        return enrollmentRepository.findStudentEnrolmentSummariesForOrganisation(organisationUuid).stream()
+                .map(row -> new StudentEnrolmentSummaryDTO(
+                        (UUID) row[0], ((Number) row[1]).longValue(), ((Number) row[2]).longValue()))
                 .toList();
     }
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImpl.java
@@ -37,6 +37,7 @@ import apps.sarafrika.elimika.timetabling.repository.EnrollmentRepository;
 import apps.sarafrika.elimika.timetabling.repository.ScheduledInstanceRepository;
 import apps.sarafrika.elimika.timetabling.spi.TimetableService;
 import apps.sarafrika.elimika.timetabling.spi.EnrollmentStatus;
+import apps.sarafrika.elimika.timetabling.spi.EnrolmentTrendPointDTO;
 import apps.sarafrika.elimika.timetabling.spi.SchedulingStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -1415,5 +1416,18 @@ public class TimetableServiceImpl implements TimetableService {
 
     private boolean matchesSearchKey(String candidate, String key) {
         return candidate.equals(key) || candidate.startsWith(key + "_");
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<EnrolmentTrendPointDTO> getEnrolmentTrendsForOrganisation(UUID organisationUuid, int months) {
+        int span = Math.max(1, months);
+        java.time.LocalDateTime since = java.time.LocalDate.now()
+                .minusMonths(span - 1L)
+                .withDayOfMonth(1)
+                .atStartOfDay();
+        return enrollmentRepository.findEnrolmentTrendsForOrganisation(organisationUuid, since).stream()
+                .map(row -> new EnrolmentTrendPointDTO((String) row[0], ((Number) row[1]).longValue()))
+                .toList();
     }
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/spi/ClassEnrolmentCountDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/spi/ClassEnrolmentCountDTO.java
@@ -1,0 +1,22 @@
+package apps.sarafrika.elimika.timetabling.spi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+/**
+ * The active enrolment count for a single class definition owned by an organisation.
+ *
+ * @param classDefinitionUuid the class definition
+ * @param enrolled            number of distinct, actively-enrolled students
+ */
+@Schema(description = "Active enrolment count for one class definition")
+public record ClassEnrolmentCountDTO(
+        @Schema(description = "Class definition UUID", format = "uuid")
+        @JsonProperty("class_definition_uuid") UUID classDefinitionUuid,
+
+        @Schema(description = "Distinct actively-enrolled students", example = "18")
+        @JsonProperty("enrolled") long enrolled
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/timetabling/spi/EnrolmentTrendPointDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/spi/EnrolmentTrendPointDTO.java
@@ -1,0 +1,21 @@
+package apps.sarafrika.elimika.timetabling.spi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * A single point in an organisation's monthly enrolment trend series.
+ *
+ * @param month the calendar month in {@code YYYY-MM} form
+ * @param total the number of enrolments recorded in that month for classes owned
+ *              by the organisation
+ */
+@Schema(description = "A single month in an organisation's enrolment trend series")
+public record EnrolmentTrendPointDTO(
+        @Schema(description = "Calendar month in YYYY-MM form", example = "2026-07")
+        @JsonProperty("month") String month,
+
+        @Schema(description = "Number of enrolments recorded in the month", example = "42")
+        @JsonProperty("total") long total
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/timetabling/spi/StudentEnrolmentSummaryDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/spi/StudentEnrolmentSummaryDTO.java
@@ -1,0 +1,28 @@
+package apps.sarafrika.elimika.timetabling.spi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+/**
+ * A student's enrolment/attendance summary within one organisation. "Completed" is
+ * derived from attendance (status = ATTENDED); "total" excludes cancelled and
+ * waitlisted enrolments.
+ *
+ * @param studentUuid the student
+ * @param total       active enrolments (not cancelled / waitlisted)
+ * @param completed   enrolments the student attended
+ */
+@Schema(description = "A student's enrolment/attendance summary within an organisation")
+public record StudentEnrolmentSummaryDTO(
+        @Schema(description = "Student UUID", format = "uuid")
+        @JsonProperty("student_uuid") UUID studentUuid,
+
+        @Schema(description = "Active enrolments (excludes cancelled/waitlisted)", example = "4")
+        @JsonProperty("total") long total,
+
+        @Schema(description = "Enrolments attended", example = "3")
+        @JsonProperty("completed") long completed
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/timetabling/spi/TimetableService.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/spi/TimetableService.java
@@ -342,4 +342,14 @@ public interface TimetableService {
      * @return list of waitlist records created
      */
     List<EnrollmentDTO> joinWaitlist(EnrollmentRequestDTO request);
+
+    /**
+     * Monthly enrolment trend for an organisation — the number of enrolments per
+     * calendar month across all classes the organisation owns.
+     *
+     * @param organisationUuid the organisation to scope the trend to
+     * @param months how many months back to include (inclusive of the current month)
+     * @return ordered list of {@link EnrolmentTrendPointDTO}, oldest month first
+     */
+    List<EnrolmentTrendPointDTO> getEnrolmentTrendsForOrganisation(UUID organisationUuid, int months);
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/spi/TimetableService.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/spi/TimetableService.java
@@ -352,4 +352,14 @@ public interface TimetableService {
      * @return ordered list of {@link EnrolmentTrendPointDTO}, oldest month first
      */
     List<EnrolmentTrendPointDTO> getEnrolmentTrendsForOrganisation(UUID organisationUuid, int months);
+
+    /**
+     * Today's hourly enrolment activity for an organisation — the number of
+     * enrolments recorded in each hour of the current day across the organisation's
+     * classes.
+     *
+     * @param organisationUuid the organisation to scope to
+     * @return ordered list of {@link TodayGrowthPointDTO}, earliest hour first
+     */
+    List<TodayGrowthPointDTO> getTodayGrowthForOrganisation(UUID organisationUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/spi/TimetableService.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/spi/TimetableService.java
@@ -362,4 +362,20 @@ public interface TimetableService {
      * @return ordered list of {@link TodayGrowthPointDTO}, earliest hour first
      */
     List<TodayGrowthPointDTO> getTodayGrowthForOrganisation(UUID organisationUuid);
+
+    /**
+     * Active enrolment counts per class definition for an organisation.
+     *
+     * @param organisationUuid the organisation to scope to
+     * @return one {@link ClassEnrolmentCountDTO} per class definition that has enrolments
+     */
+    List<ClassEnrolmentCountDTO> getClassEnrolmentCountsForOrganisation(UUID organisationUuid);
+
+    /**
+     * Per-student enrolment/attendance summaries for an organisation.
+     *
+     * @param organisationUuid the organisation to scope to
+     * @return one {@link StudentEnrolmentSummaryDTO} per student with enrolments
+     */
+    List<StudentEnrolmentSummaryDTO> getStudentEnrolmentSummariesForOrganisation(UUID organisationUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/timetabling/spi/TodayGrowthPointDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/spi/TodayGrowthPointDTO.java
@@ -1,0 +1,21 @@
+package apps.sarafrika.elimika.timetabling.spi;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * A single hour bucket in an organisation's "today's growth" series — the number
+ * of enrolments recorded in that hour of the current day.
+ *
+ * @param hour       the hour bucket in {@code HH:00} (24h) form
+ * @param enrolments the number of enrolments recorded during that hour
+ */
+@Schema(description = "An hourly bucket of today's enrolment activity for an organisation")
+public record TodayGrowthPointDTO(
+        @Schema(description = "Hour bucket in HH:00 (24h) form", example = "14:00")
+        @JsonProperty("hour") String hour,
+
+        @Schema(description = "Enrolments recorded during the hour", example = "5")
+        @JsonProperty("enrolments") long enrolments
+) {
+}

--- a/src/main/resources/db/migration/V202607241200__add_training_branch_capacity_and_venue_type.sql
+++ b/src/main/resources/db/migration/V202607241200__add_training_branch_capacity_and_venue_type.sql
@@ -1,0 +1,5 @@
+-- Venue attributes for the organisation dashboard (Lovable "Venues" cards):
+-- optional capacity and a free-form venue/room type. Both nullable — populated
+-- over time; existing rows keep NULL.
+ALTER TABLE training_branches ADD COLUMN IF NOT EXISTS capacity INTEGER;
+ALTER TABLE training_branches ADD COLUMN IF NOT EXISTS venue_type VARCHAR(50);


### PR DESCRIPTION
Adds the org-scoped, read-only data the redesigned organisation dashboard needs.

## Timetabling — analytics endpoints
`GET /api/v1/enrollment/organisations/{uuid}/…`
- `enrolment-trends?months=6` — monthly enrolment counts
- `today-growth` — hourly enrolment counts for the current day
- `class-enrolment-counts` — distinct active enrolments per class definition
- `student-summaries` — per-student total vs attended (completion)

All `@PreAuthorize("isAuthenticated()")`, org-scoped via the class_enrollments → scheduled_instances → class_definitions.organisation_uuid join.

## Tenancy — venue attributes
- Flyway `V202607241200`: nullable `capacity` (int) and `venue_type` (varchar) on `training_branches`
- `TrainingBranch` entity + `TrainingBranchDTO` + factory + controller updated

Verified locally: compiles, tests compile, migration applies and Hibernate schema-validation passes, all endpoints live in `/v3/api-docs`.