### PR TITLE
feat: org instructor-summary endpoint + student groups domain

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/instructor/controller/InstructorController.java
+++ b/src/main/java/apps/sarafrika/elimika/instructor/controller/InstructorController.java
@@ -413,6 +413,22 @@ public class InstructorController {
     }
 
     @Operation(
+            summary = "Get organisation instructor directory summaries",
+            description = "Returns one aggregated row per active instructor in the organisation — identity, " +
+                    "highest qualification, a representative skill, average rating, review count, and the number " +
+                    "of class definitions they lead. Scoped strictly to the given organisation."
+    )
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "Instructor summaries retrieved successfully")
+    @GetMapping("/organisations/{organisationUuid}/summaries")
+    public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<List<apps.sarafrika.elimika.instructor.dto.OrgInstructorSummaryDTO>>> getOrganisationInstructorSummaries(
+            @PathVariable UUID organisationUuid) {
+        List<apps.sarafrika.elimika.instructor.dto.OrgInstructorSummaryDTO> summaries =
+                instructorService.getInstructorSummariesForOrganisation(organisationUuid);
+        return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
+                .success(summaries, "Instructor summaries retrieved successfully"));
+    }
+
+    @Operation(
             summary = "Get instructor rating summary",
             description = "Returns average rating and total review count for an instructor."
     )

--- a/src/main/java/apps/sarafrika/elimika/instructor/dto/OrgInstructorSummaryDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/instructor/dto/OrgInstructorSummaryDTO.java
@@ -1,0 +1,76 @@
+package apps.sarafrika.elimika.instructor.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.UUID;
+
+/**
+ * Aggregate directory row for an instructor within an organisation.
+ * <p>
+ * Combines the instructor's identity (from the tenancy org-domain mapping), their
+ * highest recorded qualification and top skill (instructor profile), their aggregate
+ * review rating, and the number of class definitions they are the default instructor for.
+ * Powers the organisation Instructors table without per-row round-trips.
+ */
+@Schema(
+        name = "OrgInstructorSummary",
+        description = "Aggregated directory row for one instructor scoped to an organisation.",
+        example = """
+        {
+          "user_uuid": "550e8400-e29b-41d4-a716-446655440000",
+          "instructor_uuid": "inst-1234-5678-90ab-cdef12345678",
+          "full_name": "Jane Smith",
+          "email": "jane.smith@example.com",
+          "highest_qualification": "Master's Degree",
+          "field_of_study": "Computer Science",
+          "top_skill": "Cloud Computing",
+          "average_rating": 4.7,
+          "review_count": 12,
+          "class_count": 5
+        }
+        """
+)
+public record OrgInstructorSummaryDTO(
+
+        @Schema(description = "UUID of the underlying user account.")
+        @JsonProperty("user_uuid")
+        UUID userUuid,
+
+        @Schema(description = "UUID of the instructor profile.")
+        @JsonProperty("instructor_uuid")
+        UUID instructorUuid,
+
+        @Schema(description = "Instructor's full name.")
+        @JsonProperty("full_name")
+        String fullName,
+
+        @Schema(description = "Instructor's email address.", nullable = true)
+        @JsonProperty("email")
+        String email,
+
+        @Schema(description = "Most recent recorded qualification (level of study). Null when none recorded.", nullable = true)
+        @JsonProperty("highest_qualification")
+        String highestQualification,
+
+        @Schema(description = "Field of study of the most recent qualification. Null when none recorded.", nullable = true)
+        @JsonProperty("field_of_study")
+        String fieldOfStudy,
+
+        @Schema(description = "A representative skill for the instructor. Null when none recorded.", nullable = true)
+        @JsonProperty("top_skill")
+        String topSkill,
+
+        @Schema(description = "Average review rating (1-5). Null when there are no reviews.", nullable = true)
+        @JsonProperty("average_rating")
+        Double averageRating,
+
+        @Schema(description = "Total number of reviews.")
+        @JsonProperty("review_count")
+        long reviewCount,
+
+        @Schema(description = "Number of class definitions this instructor is the default instructor for.")
+        @JsonProperty("class_count")
+        long classCount
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/instructor/repository/InstructorRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/instructor/repository/InstructorRepository.java
@@ -5,12 +5,72 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
 public interface InstructorRepository extends JpaRepository<Instructor, Long>, JpaSpecificationExecutor<Instructor> {
+
+    /**
+     * Aggregated instructor directory rows for a single organisation.
+     * <p>
+     * Joins the tenancy org-domain mapping (active, non-deleted, domain = 'instructor')
+     * to the instructor profile, then LEFT JOINs the most recent qualification, a
+     * representative skill, aggregate review metrics, and the class-definition count.
+     * Column order matches {@code apps.sarafrika.elimika.instructor.dto.OrgInstructorSummaryDTO}.
+     */
+    @Query(value = """
+            SELECT
+                i.user_uuid                        AS user_uuid,
+                i.uuid                             AS instructor_uuid,
+                i.full_name                        AS full_name,
+                u.email                            AS email,
+                edu.qualification                  AS highest_qualification,
+                edu.field_of_study                 AS field_of_study,
+                sk.skill_name                      AS top_skill,
+                rv.avg_rating                      AS average_rating,
+                COALESCE(rv.review_count, 0)       AS review_count,
+                COALESCE(cd.class_count, 0)        AS class_count
+            FROM user_organisation_domain_mapping m
+            JOIN user_domain d
+                ON d.uuid = m.domain_uuid AND d.domain_name = 'instructor'
+            JOIN instructors i
+                ON i.user_uuid = m.user_uuid
+            LEFT JOIN users u
+                ON u.uuid = i.user_uuid
+            LEFT JOIN LATERAL (
+                SELECT e.qualification, e.field_of_study
+                FROM instructor_education e
+                WHERE e.instructor_uuid = i.uuid
+                ORDER BY e.year_completed DESC NULLS LAST
+                LIMIT 1
+            ) edu ON true
+            LEFT JOIN LATERAL (
+                SELECT s.skill_name
+                FROM instructor_skills s
+                WHERE s.instructor_uuid = i.uuid
+                LIMIT 1
+            ) sk ON true
+            LEFT JOIN (
+                SELECT r.instructor_uuid, AVG(r.rating) AS avg_rating, COUNT(*) AS review_count
+                FROM instructor_reviews r
+                GROUP BY r.instructor_uuid
+            ) rv ON rv.instructor_uuid = i.uuid
+            LEFT JOIN (
+                SELECT c.default_instructor_uuid, COUNT(*) AS class_count
+                FROM class_definitions c
+                GROUP BY c.default_instructor_uuid
+            ) cd ON cd.default_instructor_uuid = i.uuid
+            WHERE m.organisation_uuid = :organisationUuid
+                AND m.active = true
+                AND m.deleted = false
+            ORDER BY i.full_name ASC
+            """, nativeQuery = true)
+    List<Object[]> findInstructorSummariesForOrganisation(@Param("organisationUuid") UUID organisationUuid);
 
     Set<Instructor> findByIdIn(Set<Long> ids);
 

--- a/src/main/java/apps/sarafrika/elimika/instructor/service/InstructorService.java
+++ b/src/main/java/apps/sarafrika/elimika/instructor/service/InstructorService.java
@@ -1,9 +1,11 @@
 package apps.sarafrika.elimika.instructor.service;
 
+import apps.sarafrika.elimika.instructor.dto.OrgInstructorSummaryDTO;
 import apps.sarafrika.elimika.instructor.spi.InstructorDTO;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -73,4 +75,12 @@ public interface InstructorService {
      * @return count of instructors with the specified verification status
      */
     long countInstructorsByVerificationStatus(boolean verified);
+
+    /**
+     * Returns aggregated instructor directory rows scoped to a single organisation.
+     *
+     * @param organisationUuid the organisation to scope to
+     * @return one summary row per active instructor in the organisation
+     */
+    List<OrgInstructorSummaryDTO> getInstructorSummariesForOrganisation(UUID organisationUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/instructor/service/impl/InstructorServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/instructor/service/impl/InstructorServiceImpl.java
@@ -7,6 +7,7 @@ import apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException;
 import apps.sarafrika.elimika.shared.utils.GenericSpecificationBuilder;
 import apps.sarafrika.elimika.shared.security.DomainSecurityService;
 import apps.sarafrika.elimika.instructor.spi.InstructorDTO;
+import apps.sarafrika.elimika.instructor.dto.OrgInstructorSummaryDTO;
 import apps.sarafrika.elimika.instructor.factory.InstructorFactory;
 import apps.sarafrika.elimika.instructor.model.Instructor;
 import apps.sarafrika.elimika.instructor.repository.InstructorRepository;
@@ -20,6 +21,8 @@ import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -195,5 +198,46 @@ public class InstructorServiceImpl implements InstructorService {
         if (instructorDTO.professionalHeadline() != null) {
             instructor.setProfessionalHeadline(instructorDTO.professionalHeadline());
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<OrgInstructorSummaryDTO> getInstructorSummariesForOrganisation(UUID organisationUuid) {
+        return instructorRepository.findInstructorSummariesForOrganisation(organisationUuid).stream()
+                .map(row -> new OrgInstructorSummaryDTO(
+                        toUuid(row[0]),
+                        toUuid(row[1]),
+                        toStr(row[2]),
+                        toStr(row[3]),
+                        toStr(row[4]),
+                        toStr(row[5]),
+                        toStr(row[6]),
+                        toDouble(row[7]),
+                        toLong(row[8]),
+                        toLong(row[9])
+                ))
+                .toList();
+    }
+
+    private static UUID toUuid(Object value) {
+        if (value == null) return null;
+        if (value instanceof UUID uuid) return uuid;
+        return UUID.fromString(value.toString());
+    }
+
+    private static String toStr(Object value) {
+        return value == null ? null : value.toString();
+    }
+
+    private static Double toDouble(Object value) {
+        if (value == null) return null;
+        if (value instanceof BigDecimal bd) return bd.doubleValue();
+        if (value instanceof Number n) return n.doubleValue();
+        return null;
+    }
+
+    private static long toLong(Object value) {
+        if (value instanceof Number n) return n.longValue();
+        return 0L;
     }
 }

--- a/src/main/java/apps/sarafrika/elimika/tenancy/controller/StudentGroupController.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/controller/StudentGroupController.java
@@ -1,0 +1,74 @@
+package apps.sarafrika.elimika.tenancy.controller;
+
+import apps.sarafrika.elimika.shared.dto.ApiResponse;
+import apps.sarafrika.elimika.tenancy.dto.AddGroupMembersRequestDTO;
+import apps.sarafrika.elimika.tenancy.dto.CreateStudentGroupRequestDTO;
+import apps.sarafrika.elimika.tenancy.dto.StudentGroupDTO;
+import apps.sarafrika.elimika.tenancy.dto.StudentGroupMemberDTO;
+import apps.sarafrika.elimika.tenancy.services.StudentGroupService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("api/v1")
+@RequiredArgsConstructor
+@Tag(name = "Student Groups API", description = "Organisation-scoped student groups (cohorts/streams) and membership")
+public class StudentGroupController {
+
+    private final StudentGroupService studentGroupService;
+
+    @Operation(summary = "List student groups for an organisation", description = "Returns all student groups for the organisation with member counts.")
+    @GetMapping("/organisations/{organisationUuid}/student-groups")
+    public ResponseEntity<ApiResponse<List<StudentGroupDTO>>> listGroups(@PathVariable UUID organisationUuid) {
+        List<StudentGroupDTO> groups = studentGroupService.getGroupsForOrganisation(organisationUuid);
+        return ResponseEntity.ok(ApiResponse.success(groups, "Student groups retrieved successfully"));
+    }
+
+    @Operation(summary = "Create a student group", description = "Creates a new student group within the organisation.")
+    @PostMapping("/organisations/{organisationUuid}/student-groups")
+    public ResponseEntity<ApiResponse<StudentGroupDTO>> createGroup(
+            @PathVariable UUID organisationUuid,
+            @Valid @RequestBody CreateStudentGroupRequestDTO request) {
+        StudentGroupDTO created = studentGroupService.createGroup(organisationUuid, request);
+        return ResponseEntity.status(201).body(ApiResponse.success(created, "Student group created successfully"));
+    }
+
+    @Operation(summary = "Delete a student group", description = "Deletes a student group and its membership rows.")
+    @DeleteMapping("/student-groups/{groupUuid}")
+    public ResponseEntity<ApiResponse<Void>> deleteGroup(@PathVariable UUID groupUuid) {
+        studentGroupService.deleteGroup(groupUuid);
+        return ResponseEntity.ok(ApiResponse.success(null, "Student group deleted successfully"));
+    }
+
+    @Operation(summary = "List group members", description = "Returns the student membership rows for a group.")
+    @GetMapping("/student-groups/{groupUuid}/members")
+    public ResponseEntity<ApiResponse<List<StudentGroupMemberDTO>>> listMembers(@PathVariable UUID groupUuid) {
+        List<StudentGroupMemberDTO> members = studentGroupService.getMembers(groupUuid);
+        return ResponseEntity.ok(ApiResponse.success(members, "Group members retrieved successfully"));
+    }
+
+    @Operation(summary = "Add students to a group", description = "Adds one or more students to the group (idempotent per student).")
+    @PostMapping("/student-groups/{groupUuid}/members")
+    public ResponseEntity<ApiResponse<List<StudentGroupMemberDTO>>> addMembers(
+            @PathVariable UUID groupUuid,
+            @Valid @RequestBody AddGroupMembersRequestDTO request) {
+        List<StudentGroupMemberDTO> members = studentGroupService.addMembers(groupUuid, request.studentUuids());
+        return ResponseEntity.ok(ApiResponse.success(members, "Members added successfully"));
+    }
+
+    @Operation(summary = "Remove a student from a group")
+    @DeleteMapping("/student-groups/{groupUuid}/members/{studentUuid}")
+    public ResponseEntity<ApiResponse<Void>> removeMember(
+            @PathVariable UUID groupUuid,
+            @PathVariable UUID studentUuid) {
+        studentGroupService.removeMember(groupUuid, studentUuid);
+        return ResponseEntity.ok(ApiResponse.success(null, "Member removed successfully"));
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/AddGroupMembersRequestDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/AddGroupMembersRequestDTO.java
@@ -1,0 +1,18 @@
+package apps.sarafrika.elimika.tenancy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+import java.util.UUID;
+
+@Schema(name = "AddGroupMembersRequest", description = "Payload to add one or more students to a group.")
+public record AddGroupMembersRequestDTO(
+
+        @Schema(description = "Student user UUIDs to add.", requiredMode = Schema.RequiredMode.REQUIRED)
+        @JsonProperty("student_uuids")
+        @NotEmpty(message = "At least one student UUID is required")
+        List<UUID> studentUuids
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/CreateStudentGroupRequestDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/CreateStudentGroupRequestDTO.java
@@ -1,0 +1,23 @@
+package apps.sarafrika.elimika.tenancy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(name = "CreateStudentGroupRequest", description = "Payload to create an organisation student group.")
+public record CreateStudentGroupRequestDTO(
+
+        @Schema(description = "Group name.", requiredMode = Schema.RequiredMode.REQUIRED)
+        @JsonProperty("name")
+        @NotBlank(message = "Group name is required")
+        String name,
+
+        @Schema(description = "Optional description.", nullable = true)
+        @JsonProperty("description")
+        String description,
+
+        @Schema(description = "Optional free-form group type / stream label.", nullable = true)
+        @JsonProperty("group_type")
+        String groupType
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/StudentGroupDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/StudentGroupDTO.java
@@ -1,0 +1,40 @@
+package apps.sarafrika.elimika.tenancy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(name = "StudentGroup", description = "An organisation-scoped named collection of students.")
+public record StudentGroupDTO(
+
+        @Schema(description = "Unique identifier.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID uuid,
+
+        @Schema(description = "Owning organisation UUID.")
+        @JsonProperty("organisation_uuid")
+        UUID organisationUuid,
+
+        @Schema(description = "Group name.")
+        @JsonProperty("name")
+        String name,
+
+        @Schema(description = "Optional description.", nullable = true)
+        @JsonProperty("description")
+        String description,
+
+        @Schema(description = "Optional free-form group type / stream label.", nullable = true)
+        @JsonProperty("group_type")
+        String groupType,
+
+        @Schema(description = "Number of students in the group.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "member_count", access = JsonProperty.Access.READ_ONLY)
+        long memberCount,
+
+        @Schema(description = "When the group was created.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "created_date", access = JsonProperty.Access.READ_ONLY)
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/StudentGroupMemberDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/StudentGroupMemberDTO.java
@@ -1,0 +1,28 @@
+package apps.sarafrika.elimika.tenancy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(name = "StudentGroupMember", description = "A student's membership within a group.")
+public record StudentGroupMemberDTO(
+
+        @Schema(description = "Unique identifier.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID uuid,
+
+        @Schema(description = "Group UUID.")
+        @JsonProperty("group_uuid")
+        UUID groupUuid,
+
+        @Schema(description = "Student user UUID.")
+        @JsonProperty("student_uuid")
+        UUID studentUuid,
+
+        @Schema(description = "When the student was added.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "created_date", access = JsonProperty.Access.READ_ONLY)
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/entity/StudentGroup.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/entity/StudentGroup.java
@@ -1,0 +1,38 @@
+package apps.sarafrika.elimika.tenancy.entity;
+
+import apps.sarafrika.elimika.shared.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.UUID;
+
+/**
+ * An organisation-scoped, named collection of students (a cohort or stream).
+ */
+@Entity
+@Table(name = "student_groups")
+@Getter
+@Setter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class StudentGroup extends BaseEntity {
+
+    @Column(name = "organisation_uuid")
+    private UUID organisationUuid;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "group_type")
+    private String groupType;
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/entity/StudentGroupMember.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/entity/StudentGroupMember.java
@@ -1,0 +1,32 @@
+package apps.sarafrika.elimika.tenancy.entity;
+
+import apps.sarafrika.elimika.shared.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.UUID;
+
+/**
+ * Membership linking a student (by user UUID) to a {@link StudentGroup}.
+ */
+@Entity
+@Table(name = "student_group_members")
+@Getter
+@Setter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class StudentGroupMember extends BaseEntity {
+
+    @Column(name = "group_uuid")
+    private UUID groupUuid;
+
+    @Column(name = "student_uuid")
+    private UUID studentUuid;
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/repository/StudentGroupMemberRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/repository/StudentGroupMemberRepository.java
@@ -1,0 +1,26 @@
+package apps.sarafrika.elimika.tenancy.repository;
+
+import apps.sarafrika.elimika.tenancy.entity.StudentGroupMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface StudentGroupMemberRepository extends JpaRepository<StudentGroupMember, Long> {
+
+    List<StudentGroupMember> findByGroupUuid(UUID groupUuid);
+
+    long countByGroupUuid(UUID groupUuid);
+
+    boolean existsByGroupUuidAndStudentUuid(UUID groupUuid, UUID studentUuid);
+
+    void deleteByGroupUuidAndStudentUuid(UUID groupUuid, UUID studentUuid);
+
+    /** Member counts for a set of groups, as [groupUuid, count] rows. */
+    @Query("SELECT m.groupUuid, COUNT(m) FROM StudentGroupMember m WHERE m.groupUuid IN :groupUuids GROUP BY m.groupUuid")
+    List<Object[]> countByGroupUuids(@Param("groupUuids") List<UUID> groupUuids);
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/repository/StudentGroupRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/repository/StudentGroupRepository.java
@@ -1,0 +1,19 @@
+package apps.sarafrika.elimika.tenancy.repository;
+
+import apps.sarafrika.elimika.tenancy.entity.StudentGroup;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface StudentGroupRepository extends JpaRepository<StudentGroup, Long> {
+
+    List<StudentGroup> findByOrganisationUuidOrderByNameAsc(UUID organisationUuid);
+
+    Optional<StudentGroup> findByUuid(UUID uuid);
+
+    boolean existsByUuid(UUID uuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/services/StudentGroupService.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/services/StudentGroupService.java
@@ -1,0 +1,26 @@
+package apps.sarafrika.elimika.tenancy.services;
+
+import apps.sarafrika.elimika.tenancy.dto.CreateStudentGroupRequestDTO;
+import apps.sarafrika.elimika.tenancy.dto.StudentGroupDTO;
+import apps.sarafrika.elimika.tenancy.dto.StudentGroupMemberDTO;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Organisation student groups (cohorts / streams) and their membership.
+ */
+public interface StudentGroupService {
+
+    StudentGroupDTO createGroup(UUID organisationUuid, CreateStudentGroupRequestDTO request);
+
+    List<StudentGroupDTO> getGroupsForOrganisation(UUID organisationUuid);
+
+    void deleteGroup(UUID groupUuid);
+
+    List<StudentGroupMemberDTO> getMembers(UUID groupUuid);
+
+    List<StudentGroupMemberDTO> addMembers(UUID groupUuid, List<UUID> studentUuids);
+
+    void removeMember(UUID groupUuid, UUID studentUuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/services/impl/StudentGroupServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/services/impl/StudentGroupServiceImpl.java
@@ -1,0 +1,112 @@
+package apps.sarafrika.elimika.tenancy.services.impl;
+
+import apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException;
+import apps.sarafrika.elimika.tenancy.dto.CreateStudentGroupRequestDTO;
+import apps.sarafrika.elimika.tenancy.dto.StudentGroupDTO;
+import apps.sarafrika.elimika.tenancy.dto.StudentGroupMemberDTO;
+import apps.sarafrika.elimika.tenancy.entity.StudentGroup;
+import apps.sarafrika.elimika.tenancy.entity.StudentGroupMember;
+import apps.sarafrika.elimika.tenancy.repository.StudentGroupMemberRepository;
+import apps.sarafrika.elimika.tenancy.repository.StudentGroupRepository;
+import apps.sarafrika.elimika.tenancy.services.StudentGroupService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class StudentGroupServiceImpl implements StudentGroupService {
+
+    private final StudentGroupRepository studentGroupRepository;
+    private final StudentGroupMemberRepository studentGroupMemberRepository;
+
+    @Override
+    public StudentGroupDTO createGroup(UUID organisationUuid, CreateStudentGroupRequestDTO request) {
+        StudentGroup group = StudentGroup.builder()
+                .organisationUuid(organisationUuid)
+                .name(request.name())
+                .description(request.description())
+                .groupType(request.groupType())
+                .build();
+        StudentGroup saved = studentGroupRepository.save(group);
+        return toDTO(saved, 0L);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<StudentGroupDTO> getGroupsForOrganisation(UUID organisationUuid) {
+        List<StudentGroup> groups = studentGroupRepository.findByOrganisationUuidOrderByNameAsc(organisationUuid);
+        if (groups.isEmpty()) {
+            return List.of();
+        }
+        Map<UUID, Long> counts = new HashMap<>();
+        for (Object[] row : studentGroupMemberRepository.countByGroupUuids(groups.stream().map(StudentGroup::getUuid).toList())) {
+            counts.put((UUID) row[0], ((Number) row[1]).longValue());
+        }
+        return groups.stream()
+                .map(g -> toDTO(g, counts.getOrDefault(g.getUuid(), 0L)))
+                .toList();
+    }
+
+    @Override
+    public void deleteGroup(UUID groupUuid) {
+        StudentGroup group = findGroupOrThrow(groupUuid);
+        studentGroupRepository.delete(group);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<StudentGroupMemberDTO> getMembers(UUID groupUuid) {
+        return studentGroupMemberRepository.findByGroupUuid(groupUuid).stream()
+                .map(this::toMemberDTO)
+                .toList();
+    }
+
+    @Override
+    public List<StudentGroupMemberDTO> addMembers(UUID groupUuid, List<UUID> studentUuids) {
+        findGroupOrThrow(groupUuid);
+        for (UUID studentUuid : studentUuids) {
+            if (!studentGroupMemberRepository.existsByGroupUuidAndStudentUuid(groupUuid, studentUuid)) {
+                studentGroupMemberRepository.save(StudentGroupMember.builder()
+                        .groupUuid(groupUuid)
+                        .studentUuid(studentUuid)
+                        .build());
+            }
+        }
+        return getMembers(groupUuid);
+    }
+
+    @Override
+    public void removeMember(UUID groupUuid, UUID studentUuid) {
+        studentGroupMemberRepository.deleteByGroupUuidAndStudentUuid(groupUuid, studentUuid);
+    }
+
+    private StudentGroup findGroupOrThrow(UUID groupUuid) {
+        return studentGroupRepository.findByUuid(groupUuid)
+                .orElseThrow(() -> new ResourceNotFoundException("Student group not found: " + groupUuid));
+    }
+
+    private StudentGroupDTO toDTO(StudentGroup g, long memberCount) {
+        return new StudentGroupDTO(
+                g.getUuid(),
+                g.getOrganisationUuid(),
+                g.getName(),
+                g.getDescription(),
+                g.getGroupType(),
+                memberCount,
+                g.getCreatedDate()
+        );
+    }
+
+    private StudentGroupMemberDTO toMemberDTO(StudentGroupMember m) {
+        return new StudentGroupMemberDTO(m.getUuid(), m.getGroupUuid(), m.getStudentUuid(), m.getCreatedDate());
+    }
+}

--- a/src/main/resources/db/migration/V202607251400__create_student_groups.sql
+++ b/src/main/resources/db/migration/V202607251400__create_student_groups.sql
@@ -1,0 +1,44 @@
+-- Organisation student groups (cohorts / streams) for the org dashboard "Groups" page.
+-- A group is an org-scoped, named collection of students. Membership is a simple
+-- join table keyed by student user UUID. Both tables follow the BaseEntity audit shape.
+
+CREATE TABLE student_groups
+(
+    id                BIGSERIAL PRIMARY KEY,
+    uuid              UUID                     NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+    organisation_uuid UUID                     NOT NULL,
+    name              VARCHAR(255)             NOT NULL,
+    description       TEXT,
+    group_type        VARCHAR(100),
+
+    created_date      TIMESTAMP WITH TIME ZONE NOT NULL        DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    updated_date      TIMESTAMP WITH TIME ZONE,
+    created_by        VARCHAR(255)             NOT NULL        DEFAULT 'system',
+    updated_by        VARCHAR(255)
+);
+
+CREATE INDEX idx_student_groups_organisation ON student_groups (organisation_uuid);
+
+COMMENT ON TABLE student_groups IS
+    'Org-scoped named collections of students (cohorts/streams) shown on the organisation Groups page.';
+
+CREATE TABLE student_group_members
+(
+    id            BIGSERIAL PRIMARY KEY,
+    uuid          UUID                     NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+    group_uuid    UUID                     NOT NULL REFERENCES student_groups (uuid) ON DELETE CASCADE,
+    student_uuid  UUID                     NOT NULL,
+
+    created_date  TIMESTAMP WITH TIME ZONE NOT NULL        DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    updated_date  TIMESTAMP WITH TIME ZONE,
+    created_by    VARCHAR(255)             NOT NULL        DEFAULT 'system',
+    updated_by    VARCHAR(255)
+);
+
+CREATE UNIQUE INDEX uq_student_group_member ON student_group_members (group_uuid, student_uuid);
+CREATE INDEX idx_student_group_members_group ON student_group_members (group_uuid);
+
+COMMENT ON TABLE student_group_members IS
+    'Membership rows linking a student (by user UUID) to a student_group.';


### PR DESCRIPTION
Backend support for two organisation-dashboard pages (Lovable 1:1 port).

## Changes
- **Instructor-summary aggregate** — `GET /api/v1/instructors/organisations/{organisationUuid}/summaries`. One aggregated row per active org instructor: identity, highest qualification, a representative skill, average rating + review count, and class-definition count. Native query joining `user_organisation_domain_mapping` → `instructors` with LATERAL education/skills and grouped reviews/class-counts. Read-only.
- **Student groups domain** (cohorts/streams) — new `student_groups` + `student_group_members` tables (Flyway `V202607251400`, additive), entities, repositories, DTOs, service, and `StudentGroupController`:
  - `GET/POST /api/v1/organisations/{organisationUuid}/student-groups`
  - `DELETE /api/v1/student-groups/{groupUuid}`
  - `GET/POST /api/v1/student-groups/{groupUuid}/members`
  - `DELETE /api/v1/student-groups/{groupUuid}/members/{studentUuid}`

## Verification
- `./gradlew compileJava` + `bootJar` clean.
- Booted locally; Flyway migration applied cleanly (`v202607251400`).
- Endpoints registered in `/v3/api-docs`; instructor-summary SQL validated directly against Postgres; group tables + FK cascade verified.

Migrations are additive (CREATE TABLE only); the instructor endpoint is read-only. Frontend already wired on `main` and degrades gracefully until this deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)