### PR TITLE
feat: organisation competitions domain

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/tenancy/controller/CompetitionController.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/controller/CompetitionController.java
@@ -1,0 +1,73 @@
+package apps.sarafrika.elimika.tenancy.controller;
+
+import apps.sarafrika.elimika.shared.dto.ApiResponse;
+import apps.sarafrika.elimika.tenancy.dto.CompetitionDTO;
+import apps.sarafrika.elimika.tenancy.dto.CompetitionTeamDTO;
+import apps.sarafrika.elimika.tenancy.dto.CreateCompetitionRequestDTO;
+import apps.sarafrika.elimika.tenancy.services.CompetitionService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("api/v1")
+@RequiredArgsConstructor
+@Tag(name = "Competitions API", description = "Organisation-scoped competitions/events and team registrations")
+public class CompetitionController {
+
+    private final CompetitionService competitionService;
+
+    @Operation(summary = "List competitions for an organisation", description = "Returns all competitions for the organisation with team counts.")
+    @GetMapping("/organisations/{organisationUuid}/competitions")
+    public ResponseEntity<ApiResponse<List<CompetitionDTO>>> listCompetitions(@PathVariable UUID organisationUuid) {
+        List<CompetitionDTO> competitions = competitionService.getCompetitionsForOrganisation(organisationUuid);
+        return ResponseEntity.ok(ApiResponse.success(competitions, "Competitions retrieved successfully"));
+    }
+
+    @Operation(summary = "Create a competition")
+    @PostMapping("/organisations/{organisationUuid}/competitions")
+    public ResponseEntity<ApiResponse<CompetitionDTO>> createCompetition(
+            @PathVariable UUID organisationUuid,
+            @Valid @RequestBody CreateCompetitionRequestDTO request) {
+        CompetitionDTO created = competitionService.createCompetition(organisationUuid, request);
+        return ResponseEntity.status(201).body(ApiResponse.success(created, "Competition created successfully"));
+    }
+
+    @Operation(summary = "Delete a competition")
+    @DeleteMapping("/competitions/{competitionUuid}")
+    public ResponseEntity<ApiResponse<Void>> deleteCompetition(@PathVariable UUID competitionUuid) {
+        competitionService.deleteCompetition(competitionUuid);
+        return ResponseEntity.ok(ApiResponse.success(null, "Competition deleted successfully"));
+    }
+
+    @Operation(summary = "List competition teams")
+    @GetMapping("/competitions/{competitionUuid}/teams")
+    public ResponseEntity<ApiResponse<List<CompetitionTeamDTO>>> listTeams(@PathVariable UUID competitionUuid) {
+        List<CompetitionTeamDTO> teams = competitionService.getTeams(competitionUuid);
+        return ResponseEntity.ok(ApiResponse.success(teams, "Competition teams retrieved successfully"));
+    }
+
+    @Operation(summary = "Register a team for a competition")
+    @PostMapping("/competitions/{competitionUuid}/teams")
+    public ResponseEntity<ApiResponse<CompetitionTeamDTO>> addTeam(
+            @PathVariable UUID competitionUuid,
+            @Valid @RequestBody CompetitionTeamDTO request) {
+        CompetitionTeamDTO created = competitionService.addTeam(competitionUuid, request.teamName());
+        return ResponseEntity.status(201).body(ApiResponse.success(created, "Team registered successfully"));
+    }
+
+    @Operation(summary = "Remove a team from a competition")
+    @DeleteMapping("/competitions/{competitionUuid}/teams/{teamUuid}")
+    public ResponseEntity<ApiResponse<Void>> removeTeam(
+            @PathVariable UUID competitionUuid,
+            @PathVariable UUID teamUuid) {
+        competitionService.removeTeam(competitionUuid, teamUuid);
+        return ResponseEntity.ok(ApiResponse.success(null, "Team removed successfully"));
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/CompetitionDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/CompetitionDTO.java
@@ -1,0 +1,56 @@
+package apps.sarafrika.elimika.tenancy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(name = "Competition", description = "An organisation-scoped competition/event.")
+public record CompetitionDTO(
+
+        @Schema(description = "Unique identifier.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID uuid,
+
+        @Schema(description = "Owning organisation UUID.")
+        @JsonProperty("organisation_uuid")
+        UUID organisationUuid,
+
+        @Schema(description = "Competition name.")
+        @JsonProperty("name")
+        String name,
+
+        @Schema(description = "Category (e.g. STEM, Music, TVET).", nullable = true)
+        @JsonProperty("category")
+        String category,
+
+        @Schema(description = "Scheduled date/time of the event.", nullable = true)
+        @JsonProperty("event_date")
+        LocalDateTime eventDate,
+
+        @Schema(description = "Venue name.", nullable = true)
+        @JsonProperty("venue_name")
+        String venueName,
+
+        @Schema(description = "Maximum number of teams.", nullable = true)
+        @JsonProperty("capacity")
+        Integer capacity,
+
+        @Schema(description = "Lifecycle status (Upcoming, Registration Open, In Progress, Completed).")
+        @JsonProperty("status")
+        String status,
+
+        @Schema(description = "Optional description.", nullable = true)
+        @JsonProperty("description")
+        String description,
+
+        @Schema(description = "Number of teams registered.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "team_count", access = JsonProperty.Access.READ_ONLY)
+        long teamCount,
+
+        @Schema(description = "When the competition was created.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "created_date", access = JsonProperty.Access.READ_ONLY)
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/CompetitionTeamDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/CompetitionTeamDTO.java
@@ -1,0 +1,30 @@
+package apps.sarafrika.elimika.tenancy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(name = "CompetitionTeam", description = "A team registered for a competition.")
+public record CompetitionTeamDTO(
+
+        @Schema(description = "Unique identifier.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID uuid,
+
+        @Schema(description = "Competition UUID.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "competition_uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID competitionUuid,
+
+        @Schema(description = "Team name.", requiredMode = Schema.RequiredMode.REQUIRED)
+        @JsonProperty("team_name")
+        @NotBlank(message = "Team name is required")
+        String teamName,
+
+        @Schema(description = "When the team registered.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "created_date", access = JsonProperty.Access.READ_ONLY)
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/CreateCompetitionRequestDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/CreateCompetitionRequestDTO.java
@@ -1,0 +1,41 @@
+package apps.sarafrika.elimika.tenancy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+import java.time.LocalDateTime;
+
+@Schema(name = "CreateCompetitionRequest", description = "Payload to create an organisation competition.")
+public record CreateCompetitionRequestDTO(
+
+        @Schema(description = "Competition name.", requiredMode = Schema.RequiredMode.REQUIRED)
+        @JsonProperty("name")
+        @NotBlank(message = "Competition name is required")
+        String name,
+
+        @Schema(description = "Category.", nullable = true)
+        @JsonProperty("category")
+        String category,
+
+        @Schema(description = "Scheduled date/time.", nullable = true)
+        @JsonProperty("event_date")
+        LocalDateTime eventDate,
+
+        @Schema(description = "Venue name.", nullable = true)
+        @JsonProperty("venue_name")
+        String venueName,
+
+        @Schema(description = "Maximum number of teams.", nullable = true)
+        @JsonProperty("capacity")
+        Integer capacity,
+
+        @Schema(description = "Lifecycle status. Defaults to Upcoming when omitted.", nullable = true)
+        @JsonProperty("status")
+        String status,
+
+        @Schema(description = "Optional description.", nullable = true)
+        @JsonProperty("description")
+        String description
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/entity/Competition.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/entity/Competition.java
@@ -1,0 +1,51 @@
+package apps.sarafrika.elimika.tenancy.entity;
+
+import apps.sarafrika.elimika.shared.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * An organisation-scoped competition/event.
+ */
+@Entity
+@Table(name = "competitions")
+@Getter
+@Setter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class Competition extends BaseEntity {
+
+    @Column(name = "organisation_uuid")
+    private UUID organisationUuid;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "category")
+    private String category;
+
+    @Column(name = "event_date")
+    private LocalDateTime eventDate;
+
+    @Column(name = "venue_name")
+    private String venueName;
+
+    @Column(name = "capacity")
+    private Integer capacity;
+
+    @Column(name = "status")
+    private String status;
+
+    @Column(name = "description")
+    private String description;
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/entity/CompetitionTeam.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/entity/CompetitionTeam.java
@@ -1,0 +1,32 @@
+package apps.sarafrika.elimika.tenancy.entity;
+
+import apps.sarafrika.elimika.shared.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.UUID;
+
+/**
+ * A team registered for a {@link Competition}.
+ */
+@Entity
+@Table(name = "competition_teams")
+@Getter
+@Setter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CompetitionTeam extends BaseEntity {
+
+    @Column(name = "competition_uuid")
+    private UUID competitionUuid;
+
+    @Column(name = "team_name")
+    private String teamName;
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/repository/CompetitionRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/repository/CompetitionRepository.java
@@ -1,0 +1,17 @@
+package apps.sarafrika.elimika.tenancy.repository;
+
+import apps.sarafrika.elimika.tenancy.entity.Competition;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface CompetitionRepository extends JpaRepository<Competition, Long> {
+
+    List<Competition> findByOrganisationUuidOrderByEventDateAsc(UUID organisationUuid);
+
+    Optional<Competition> findByUuid(UUID uuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/repository/CompetitionTeamRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/repository/CompetitionTeamRepository.java
@@ -1,0 +1,22 @@
+package apps.sarafrika.elimika.tenancy.repository;
+
+import apps.sarafrika.elimika.tenancy.entity.CompetitionTeam;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface CompetitionTeamRepository extends JpaRepository<CompetitionTeam, Long> {
+
+    List<CompetitionTeam> findByCompetitionUuid(UUID competitionUuid);
+
+    void deleteByCompetitionUuidAndUuid(UUID competitionUuid, UUID uuid);
+
+    /** Team counts for a set of competitions, as [competitionUuid, count] rows. */
+    @Query("SELECT t.competitionUuid, COUNT(t) FROM CompetitionTeam t WHERE t.competitionUuid IN :competitionUuids GROUP BY t.competitionUuid")
+    List<Object[]> countByCompetitionUuids(@Param("competitionUuids") List<UUID> competitionUuids);
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/services/CompetitionService.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/services/CompetitionService.java
@@ -1,0 +1,26 @@
+package apps.sarafrika.elimika.tenancy.services;
+
+import apps.sarafrika.elimika.tenancy.dto.CompetitionDTO;
+import apps.sarafrika.elimika.tenancy.dto.CompetitionTeamDTO;
+import apps.sarafrika.elimika.tenancy.dto.CreateCompetitionRequestDTO;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Organisation competitions/events and their team registrations.
+ */
+public interface CompetitionService {
+
+    CompetitionDTO createCompetition(UUID organisationUuid, CreateCompetitionRequestDTO request);
+
+    List<CompetitionDTO> getCompetitionsForOrganisation(UUID organisationUuid);
+
+    void deleteCompetition(UUID competitionUuid);
+
+    List<CompetitionTeamDTO> getTeams(UUID competitionUuid);
+
+    CompetitionTeamDTO addTeam(UUID competitionUuid, String teamName);
+
+    void removeTeam(UUID competitionUuid, UUID teamUuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/services/impl/CompetitionServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/services/impl/CompetitionServiceImpl.java
@@ -1,0 +1,115 @@
+package apps.sarafrika.elimika.tenancy.services.impl;
+
+import apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException;
+import apps.sarafrika.elimika.tenancy.dto.CompetitionDTO;
+import apps.sarafrika.elimika.tenancy.dto.CompetitionTeamDTO;
+import apps.sarafrika.elimika.tenancy.dto.CreateCompetitionRequestDTO;
+import apps.sarafrika.elimika.tenancy.entity.Competition;
+import apps.sarafrika.elimika.tenancy.entity.CompetitionTeam;
+import apps.sarafrika.elimika.tenancy.repository.CompetitionRepository;
+import apps.sarafrika.elimika.tenancy.repository.CompetitionTeamRepository;
+import apps.sarafrika.elimika.tenancy.services.CompetitionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class CompetitionServiceImpl implements CompetitionService {
+
+    private final CompetitionRepository competitionRepository;
+    private final CompetitionTeamRepository competitionTeamRepository;
+
+    @Override
+    public CompetitionDTO createCompetition(UUID organisationUuid, CreateCompetitionRequestDTO request) {
+        Competition competition = Competition.builder()
+                .organisationUuid(organisationUuid)
+                .name(request.name())
+                .category(request.category())
+                .eventDate(request.eventDate())
+                .venueName(request.venueName())
+                .capacity(request.capacity())
+                .status(request.status() != null && !request.status().isBlank() ? request.status() : "Upcoming")
+                .description(request.description())
+                .build();
+        return toDTO(competitionRepository.save(competition), 0L);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CompetitionDTO> getCompetitionsForOrganisation(UUID organisationUuid) {
+        List<Competition> competitions = competitionRepository.findByOrganisationUuidOrderByEventDateAsc(organisationUuid);
+        if (competitions.isEmpty()) {
+            return List.of();
+        }
+        Map<UUID, Long> counts = new HashMap<>();
+        for (Object[] row : competitionTeamRepository.countByCompetitionUuids(competitions.stream().map(Competition::getUuid).toList())) {
+            counts.put((UUID) row[0], ((Number) row[1]).longValue());
+        }
+        return competitions.stream()
+                .map(c -> toDTO(c, counts.getOrDefault(c.getUuid(), 0L)))
+                .toList();
+    }
+
+    @Override
+    public void deleteCompetition(UUID competitionUuid) {
+        Competition competition = findOrThrow(competitionUuid);
+        competitionRepository.delete(competition);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<CompetitionTeamDTO> getTeams(UUID competitionUuid) {
+        return competitionTeamRepository.findByCompetitionUuid(competitionUuid).stream()
+                .map(this::toTeamDTO)
+                .toList();
+    }
+
+    @Override
+    public CompetitionTeamDTO addTeam(UUID competitionUuid, String teamName) {
+        findOrThrow(competitionUuid);
+        CompetitionTeam team = competitionTeamRepository.save(CompetitionTeam.builder()
+                .competitionUuid(competitionUuid)
+                .teamName(teamName)
+                .build());
+        return toTeamDTO(team);
+    }
+
+    @Override
+    public void removeTeam(UUID competitionUuid, UUID teamUuid) {
+        competitionTeamRepository.deleteByCompetitionUuidAndUuid(competitionUuid, teamUuid);
+    }
+
+    private Competition findOrThrow(UUID competitionUuid) {
+        return competitionRepository.findByUuid(competitionUuid)
+                .orElseThrow(() -> new ResourceNotFoundException("Competition not found: " + competitionUuid));
+    }
+
+    private CompetitionDTO toDTO(Competition c, long teamCount) {
+        return new CompetitionDTO(
+                c.getUuid(),
+                c.getOrganisationUuid(),
+                c.getName(),
+                c.getCategory(),
+                c.getEventDate(),
+                c.getVenueName(),
+                c.getCapacity(),
+                c.getStatus(),
+                c.getDescription(),
+                teamCount,
+                c.getCreatedDate()
+        );
+    }
+
+    private CompetitionTeamDTO toTeamDTO(CompetitionTeam t) {
+        return new CompetitionTeamDTO(t.getUuid(), t.getCompetitionUuid(), t.getTeamName(), t.getCreatedDate());
+    }
+}

--- a/src/main/resources/db/migration/V202607261000__create_competitions.sql
+++ b/src/main/resources/db/migration/V202607261000__create_competitions.sql
@@ -1,0 +1,47 @@
+-- Organisation competitions (events) for the org dashboard "Competition" page.
+-- A competition is an org-scoped event with a category, date, venue and capacity.
+-- Team registrations live in a child table; the teams count is derived from it.
+
+CREATE TABLE competitions
+(
+    id                BIGSERIAL PRIMARY KEY,
+    uuid              UUID                     NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+    organisation_uuid UUID                     NOT NULL,
+    name              VARCHAR(255)             NOT NULL,
+    category          VARCHAR(120),
+    event_date        TIMESTAMP WITH TIME ZONE,
+    venue_name        VARCHAR(255),
+    capacity          INTEGER,
+    status            VARCHAR(50)              NOT NULL        DEFAULT 'Upcoming',
+    description       TEXT,
+
+    created_date      TIMESTAMP WITH TIME ZONE NOT NULL        DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    updated_date      TIMESTAMP WITH TIME ZONE,
+    created_by        VARCHAR(255)             NOT NULL        DEFAULT 'system',
+    updated_by        VARCHAR(255)
+);
+
+CREATE INDEX idx_competitions_organisation ON competitions (organisation_uuid);
+
+COMMENT ON TABLE competitions IS
+    'Org-scoped competitions/events shown on the organisation Competition page.';
+
+CREATE TABLE competition_teams
+(
+    id                BIGSERIAL PRIMARY KEY,
+    uuid              UUID                     NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+    competition_uuid  UUID                     NOT NULL REFERENCES competitions (uuid) ON DELETE CASCADE,
+    team_name         VARCHAR(255)             NOT NULL,
+
+    created_date      TIMESTAMP WITH TIME ZONE NOT NULL        DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    updated_date      TIMESTAMP WITH TIME ZONE,
+    created_by        VARCHAR(255)             NOT NULL        DEFAULT 'system',
+    updated_by        VARCHAR(255)
+);
+
+CREATE INDEX idx_competition_teams_competition ON competition_teams (competition_uuid);
+
+COMMENT ON TABLE competition_teams IS
+    'Team registrations for a competition. Teams count is derived from these rows.';


### PR DESCRIPTION
Backend support for the organisation dashboard **Competition** page (Lovable 1:1 port).

## Changes
- New `competitions` + `competition_teams` tables (Flyway `V202607261000`, additive), entities, repositories, DTOs, service, and `CompetitionController`:
  - `GET/POST /api/v1/organisations/{organisationUuid}/competitions`
  - `DELETE /api/v1/competitions/{competitionUuid}`
  - `GET/POST /api/v1/competitions/{competitionUuid}/teams`
  - `DELETE /api/v1/competitions/{competitionUuid}/teams/{teamUuid}`
- List returns each competition with a derived `team_count`.

## Verification
- `compileJava` + `bootJar` clean; booted locally, migration applied cleanly (`v202607261000`).
- Endpoints registered in `/v3/api-docs`; tables + FK cascade verified.

Migrations are additive (CREATE TABLE only). Frontend already wired on `main`; degrades gracefully until deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)