### PR TITLE
feat: organisation skills fund domain

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/tenancy/controller/SkillsFundController.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/controller/SkillsFundController.java
@@ -1,0 +1,77 @@
+package apps.sarafrika.elimika.tenancy.controller;
+
+import apps.sarafrika.elimika.shared.dto.ApiResponse;
+import apps.sarafrika.elimika.tenancy.dto.CreateSkillsFundSourceRequestDTO;
+import apps.sarafrika.elimika.tenancy.dto.CreateSkillsFundTransactionRequestDTO;
+import apps.sarafrika.elimika.tenancy.dto.SkillsFundSourceDTO;
+import apps.sarafrika.elimika.tenancy.dto.SkillsFundSummaryDTO;
+import apps.sarafrika.elimika.tenancy.dto.SkillsFundTransactionDTO;
+import apps.sarafrika.elimika.tenancy.services.SkillsFundService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("api/v1")
+@RequiredArgsConstructor
+@Tag(name = "Skills Fund API", description = "Organisation skills fund — sources, transactions and computed KPIs")
+public class SkillsFundController {
+
+    private final SkillsFundService skillsFundService;
+
+    @Operation(summary = "Get skills fund summary (KPIs)")
+    @GetMapping("/organisations/{organisationUuid}/skills-fund/summary")
+    public ResponseEntity<ApiResponse<SkillsFundSummaryDTO>> getSummary(@PathVariable UUID organisationUuid) {
+        return ResponseEntity.ok(ApiResponse.success(skillsFundService.getSummary(organisationUuid), "Skills fund summary retrieved successfully"));
+    }
+
+    @Operation(summary = "List funding sources")
+    @GetMapping("/organisations/{organisationUuid}/skills-fund/sources")
+    public ResponseEntity<ApiResponse<List<SkillsFundSourceDTO>>> listSources(@PathVariable UUID organisationUuid) {
+        return ResponseEntity.ok(ApiResponse.success(skillsFundService.getSources(organisationUuid), "Funding sources retrieved successfully"));
+    }
+
+    @Operation(summary = "Add a funding source")
+    @PostMapping("/organisations/{organisationUuid}/skills-fund/sources")
+    public ResponseEntity<ApiResponse<SkillsFundSourceDTO>> addSource(
+            @PathVariable UUID organisationUuid,
+            @Valid @RequestBody CreateSkillsFundSourceRequestDTO request) {
+        SkillsFundSourceDTO created = skillsFundService.addSource(organisationUuid, request);
+        return ResponseEntity.status(201).body(ApiResponse.success(created, "Funding source added successfully"));
+    }
+
+    @Operation(summary = "Delete a funding source")
+    @DeleteMapping("/skills-fund/sources/{sourceUuid}")
+    public ResponseEntity<ApiResponse<Void>> deleteSource(@PathVariable UUID sourceUuid) {
+        skillsFundService.deleteSource(sourceUuid);
+        return ResponseEntity.ok(ApiResponse.success(null, "Funding source deleted successfully"));
+    }
+
+    @Operation(summary = "List fund transactions")
+    @GetMapping("/organisations/{organisationUuid}/skills-fund/transactions")
+    public ResponseEntity<ApiResponse<List<SkillsFundTransactionDTO>>> listTransactions(@PathVariable UUID organisationUuid) {
+        return ResponseEntity.ok(ApiResponse.success(skillsFundService.getTransactions(organisationUuid), "Fund transactions retrieved successfully"));
+    }
+
+    @Operation(summary = "Record a fund transaction")
+    @PostMapping("/organisations/{organisationUuid}/skills-fund/transactions")
+    public ResponseEntity<ApiResponse<SkillsFundTransactionDTO>> addTransaction(
+            @PathVariable UUID organisationUuid,
+            @Valid @RequestBody CreateSkillsFundTransactionRequestDTO request) {
+        SkillsFundTransactionDTO created = skillsFundService.addTransaction(organisationUuid, request);
+        return ResponseEntity.status(201).body(ApiResponse.success(created, "Transaction recorded successfully"));
+    }
+
+    @Operation(summary = "Delete a fund transaction")
+    @DeleteMapping("/skills-fund/transactions/{transactionUuid}")
+    public ResponseEntity<ApiResponse<Void>> deleteTransaction(@PathVariable UUID transactionUuid) {
+        skillsFundService.deleteTransaction(transactionUuid);
+        return ResponseEntity.ok(ApiResponse.success(null, "Transaction deleted successfully"));
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/CreateSkillsFundSourceRequestDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/CreateSkillsFundSourceRequestDTO.java
@@ -1,0 +1,23 @@
+package apps.sarafrika.elimika.tenancy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+import java.math.BigDecimal;
+
+@Schema(name = "CreateSkillsFundSourceRequest", description = "Payload to add a funding source.")
+public record CreateSkillsFundSourceRequestDTO(
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED)
+        @JsonProperty("name")
+        @NotBlank(message = "Source name is required")
+        String name,
+
+        @JsonProperty("source_type")
+        String sourceType,
+
+        @JsonProperty("amount")
+        BigDecimal amount
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/CreateSkillsFundTransactionRequestDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/CreateSkillsFundTransactionRequestDTO.java
@@ -1,0 +1,32 @@
+package apps.sarafrika.elimika.tenancy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Schema(name = "CreateSkillsFundTransactionRequest", description = "Payload to record a skills fund movement.")
+public record CreateSkillsFundTransactionRequestDTO(
+
+        @JsonProperty("description")
+        String description,
+
+        @JsonProperty("target_name")
+        String targetName,
+
+        @JsonProperty("amount")
+        BigDecimal amount,
+
+        @Schema(description = "Type: Allocation, Disbursement, Adjustment. Defaults to Allocation.")
+        @JsonProperty("transaction_type")
+        String transactionType,
+
+        @Schema(description = "Status. Defaults to Pending.")
+        @JsonProperty("status")
+        String status,
+
+        @JsonProperty("transaction_date")
+        LocalDateTime transactionDate
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/SkillsFundSourceDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/SkillsFundSourceDTO.java
@@ -1,0 +1,36 @@
+package apps.sarafrika.elimika.tenancy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(name = "SkillsFundSource", description = "A funding source for an organisation's skills fund.")
+public record SkillsFundSourceDTO(
+
+        @Schema(accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID uuid,
+
+        @JsonProperty("organisation_uuid")
+        UUID organisationUuid,
+
+        @Schema(description = "Source name.")
+        @JsonProperty("name")
+        String name,
+
+        @Schema(description = "Source type (e.g. Government Grant, Sponsor/Donor).", nullable = true)
+        @JsonProperty("source_type")
+        String sourceType,
+
+        @Schema(description = "Amount contributed.")
+        @JsonProperty("amount")
+        BigDecimal amount,
+
+        @Schema(accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "created_date", access = JsonProperty.Access.READ_ONLY)
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/SkillsFundSummaryDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/SkillsFundSummaryDTO.java
@@ -1,0 +1,31 @@
+package apps.sarafrika.elimika.tenancy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+
+@Schema(name = "SkillsFundSummary", description = "Computed KPI roll-up for an organisation's skills fund.")
+public record SkillsFundSummaryDTO(
+
+        @Schema(description = "Total contributed across all funding sources.")
+        @JsonProperty("total_balance")
+        BigDecimal totalBalance,
+
+        @Schema(description = "Amount allocated (approved/allocated transactions).")
+        @JsonProperty("allocated")
+        BigDecimal allocated,
+
+        @Schema(description = "Amount disbursed (completed transactions).")
+        @JsonProperty("disbursed")
+        BigDecimal disbursed,
+
+        @Schema(description = "Amount in pending requests.")
+        @JsonProperty("pending")
+        BigDecimal pending,
+
+        @Schema(description = "Remaining = total balance − disbursed.")
+        @JsonProperty("remaining")
+        BigDecimal remaining
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/dto/SkillsFundTransactionDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/dto/SkillsFundTransactionDTO.java
@@ -1,0 +1,48 @@
+package apps.sarafrika.elimika.tenancy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Schema(name = "SkillsFundTransaction", description = "A movement within an organisation's skills fund.")
+public record SkillsFundTransactionDTO(
+
+        @Schema(accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "uuid", access = JsonProperty.Access.READ_ONLY)
+        UUID uuid,
+
+        @JsonProperty("organisation_uuid")
+        UUID organisationUuid,
+
+        @Schema(description = "Human-readable description.", nullable = true)
+        @JsonProperty("description")
+        String description,
+
+        @Schema(description = "Recipient / target of the movement.", nullable = true)
+        @JsonProperty("target_name")
+        String targetName,
+
+        @Schema(description = "Amount.")
+        @JsonProperty("amount")
+        BigDecimal amount,
+
+        @Schema(description = "Type: Allocation, Disbursement, Adjustment.")
+        @JsonProperty("transaction_type")
+        String transactionType,
+
+        @Schema(description = "Status: Pending, Allocated, Approved, Completed.")
+        @JsonProperty("status")
+        String status,
+
+        @Schema(nullable = true)
+        @JsonProperty("transaction_date")
+        LocalDateTime transactionDate,
+
+        @Schema(accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty(value = "created_date", access = JsonProperty.Access.READ_ONLY)
+        LocalDateTime createdDate
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/entity/SkillsFundSource.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/entity/SkillsFundSource.java
@@ -1,0 +1,39 @@
+package apps.sarafrika.elimika.tenancy.entity;
+
+import apps.sarafrika.elimika.shared.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+/**
+ * A funding source contributing to an organisation's skills fund.
+ */
+@Entity
+@Table(name = "skills_fund_sources")
+@Getter
+@Setter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SkillsFundSource extends BaseEntity {
+
+    @Column(name = "organisation_uuid")
+    private UUID organisationUuid;
+
+    @Column(name = "name")
+    private String name;
+
+    @Column(name = "source_type")
+    private String sourceType;
+
+    @Column(name = "amount")
+    private BigDecimal amount;
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/entity/SkillsFundTransaction.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/entity/SkillsFundTransaction.java
@@ -1,0 +1,49 @@
+package apps.sarafrika.elimika.tenancy.entity;
+
+import apps.sarafrika.elimika.shared.model.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.experimental.SuperBuilder;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * A movement within an organisation's skills fund (allocation, disbursement, adjustment).
+ */
+@Entity
+@Table(name = "skills_fund_transactions")
+@Getter
+@Setter
+@SuperBuilder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SkillsFundTransaction extends BaseEntity {
+
+    @Column(name = "organisation_uuid")
+    private UUID organisationUuid;
+
+    @Column(name = "description")
+    private String description;
+
+    @Column(name = "target_name")
+    private String targetName;
+
+    @Column(name = "amount")
+    private BigDecimal amount;
+
+    @Column(name = "transaction_type")
+    private String transactionType;
+
+    @Column(name = "status")
+    private String status;
+
+    @Column(name = "transaction_date")
+    private LocalDateTime transactionDate;
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/repository/SkillsFundSourceRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/repository/SkillsFundSourceRepository.java
@@ -1,0 +1,17 @@
+package apps.sarafrika.elimika.tenancy.repository;
+
+import apps.sarafrika.elimika.tenancy.entity.SkillsFundSource;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface SkillsFundSourceRepository extends JpaRepository<SkillsFundSource, Long> {
+
+    List<SkillsFundSource> findByOrganisationUuidOrderByNameAsc(UUID organisationUuid);
+
+    Optional<SkillsFundSource> findByUuid(UUID uuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/repository/SkillsFundTransactionRepository.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/repository/SkillsFundTransactionRepository.java
@@ -1,0 +1,17 @@
+package apps.sarafrika.elimika.tenancy.repository;
+
+import apps.sarafrika.elimika.tenancy.entity.SkillsFundTransaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface SkillsFundTransactionRepository extends JpaRepository<SkillsFundTransaction, Long> {
+
+    List<SkillsFundTransaction> findByOrganisationUuidOrderByTransactionDateDesc(UUID organisationUuid);
+
+    Optional<SkillsFundTransaction> findByUuid(UUID uuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/services/SkillsFundService.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/services/SkillsFundService.java
@@ -1,0 +1,30 @@
+package apps.sarafrika.elimika.tenancy.services;
+
+import apps.sarafrika.elimika.tenancy.dto.CreateSkillsFundSourceRequestDTO;
+import apps.sarafrika.elimika.tenancy.dto.CreateSkillsFundTransactionRequestDTO;
+import apps.sarafrika.elimika.tenancy.dto.SkillsFundSourceDTO;
+import apps.sarafrika.elimika.tenancy.dto.SkillsFundSummaryDTO;
+import apps.sarafrika.elimika.tenancy.dto.SkillsFundTransactionDTO;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * An organisation's skills fund — funding sources, transactions and computed KPIs.
+ */
+public interface SkillsFundService {
+
+    SkillsFundSummaryDTO getSummary(UUID organisationUuid);
+
+    List<SkillsFundSourceDTO> getSources(UUID organisationUuid);
+
+    SkillsFundSourceDTO addSource(UUID organisationUuid, CreateSkillsFundSourceRequestDTO request);
+
+    void deleteSource(UUID sourceUuid);
+
+    List<SkillsFundTransactionDTO> getTransactions(UUID organisationUuid);
+
+    SkillsFundTransactionDTO addTransaction(UUID organisationUuid, CreateSkillsFundTransactionRequestDTO request);
+
+    void deleteTransaction(UUID transactionUuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/tenancy/services/impl/SkillsFundServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/tenancy/services/impl/SkillsFundServiceImpl.java
@@ -1,0 +1,127 @@
+package apps.sarafrika.elimika.tenancy.services.impl;
+
+import apps.sarafrika.elimika.shared.exceptions.ResourceNotFoundException;
+import apps.sarafrika.elimika.tenancy.dto.CreateSkillsFundSourceRequestDTO;
+import apps.sarafrika.elimika.tenancy.dto.CreateSkillsFundTransactionRequestDTO;
+import apps.sarafrika.elimika.tenancy.dto.SkillsFundSourceDTO;
+import apps.sarafrika.elimika.tenancy.dto.SkillsFundSummaryDTO;
+import apps.sarafrika.elimika.tenancy.dto.SkillsFundTransactionDTO;
+import apps.sarafrika.elimika.tenancy.entity.SkillsFundSource;
+import apps.sarafrika.elimika.tenancy.entity.SkillsFundTransaction;
+import apps.sarafrika.elimika.tenancy.repository.SkillsFundSourceRepository;
+import apps.sarafrika.elimika.tenancy.repository.SkillsFundTransactionRepository;
+import apps.sarafrika.elimika.tenancy.services.SkillsFundService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class SkillsFundServiceImpl implements SkillsFundService {
+
+    private final SkillsFundSourceRepository sourceRepository;
+    private final SkillsFundTransactionRepository transactionRepository;
+
+    private static BigDecimal nz(BigDecimal v) {
+        return v == null ? BigDecimal.ZERO : v;
+    }
+
+    private static boolean isStatus(SkillsFundTransaction t, String... statuses) {
+        String s = t.getStatus() == null ? "" : t.getStatus().toLowerCase();
+        for (String status : statuses) {
+            if (s.equals(status.toLowerCase())) return true;
+        }
+        return false;
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public SkillsFundSummaryDTO getSummary(UUID organisationUuid) {
+        BigDecimal totalBalance = sourceRepository.findByOrganisationUuidOrderByNameAsc(organisationUuid).stream()
+                .map(s -> nz(s.getAmount()))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        List<SkillsFundTransaction> txns = transactionRepository.findByOrganisationUuidOrderByTransactionDateDesc(organisationUuid);
+        BigDecimal disbursed = txns.stream().filter(t -> isStatus(t, "Completed", "Disbursed"))
+                .map(t -> nz(t.getAmount())).reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal allocated = txns.stream().filter(t -> isStatus(t, "Allocated", "Approved", "Completed"))
+                .map(t -> nz(t.getAmount())).reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal pending = txns.stream().filter(t -> isStatus(t, "Pending"))
+                .map(t -> nz(t.getAmount())).reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal remaining = totalBalance.subtract(disbursed);
+
+        return new SkillsFundSummaryDTO(totalBalance, allocated, disbursed, pending, remaining);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<SkillsFundSourceDTO> getSources(UUID organisationUuid) {
+        return sourceRepository.findByOrganisationUuidOrderByNameAsc(organisationUuid).stream()
+                .map(this::toSourceDTO)
+                .toList();
+    }
+
+    @Override
+    public SkillsFundSourceDTO addSource(UUID organisationUuid, CreateSkillsFundSourceRequestDTO request) {
+        SkillsFundSource source = SkillsFundSource.builder()
+                .organisationUuid(organisationUuid)
+                .name(request.name())
+                .sourceType(request.sourceType())
+                .amount(nz(request.amount()))
+                .build();
+        return toSourceDTO(sourceRepository.save(source));
+    }
+
+    @Override
+    public void deleteSource(UUID sourceUuid) {
+        SkillsFundSource source = sourceRepository.findByUuid(sourceUuid)
+                .orElseThrow(() -> new ResourceNotFoundException("Funding source not found: " + sourceUuid));
+        sourceRepository.delete(source);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<SkillsFundTransactionDTO> getTransactions(UUID organisationUuid) {
+        return transactionRepository.findByOrganisationUuidOrderByTransactionDateDesc(organisationUuid).stream()
+                .map(this::toTransactionDTO)
+                .toList();
+    }
+
+    @Override
+    public SkillsFundTransactionDTO addTransaction(UUID organisationUuid, CreateSkillsFundTransactionRequestDTO request) {
+        SkillsFundTransaction txn = SkillsFundTransaction.builder()
+                .organisationUuid(organisationUuid)
+                .description(request.description())
+                .targetName(request.targetName())
+                .amount(nz(request.amount()))
+                .transactionType(request.transactionType() != null && !request.transactionType().isBlank() ? request.transactionType() : "Allocation")
+                .status(request.status() != null && !request.status().isBlank() ? request.status() : "Pending")
+                .transactionDate(request.transactionDate() != null ? request.transactionDate() : java.time.LocalDateTime.now())
+                .build();
+        return toTransactionDTO(transactionRepository.save(txn));
+    }
+
+    @Override
+    public void deleteTransaction(UUID transactionUuid) {
+        SkillsFundTransaction txn = transactionRepository.findByUuid(transactionUuid)
+                .orElseThrow(() -> new ResourceNotFoundException("Transaction not found: " + transactionUuid));
+        transactionRepository.delete(txn);
+    }
+
+    private SkillsFundSourceDTO toSourceDTO(SkillsFundSource s) {
+        return new SkillsFundSourceDTO(s.getUuid(), s.getOrganisationUuid(), s.getName(), s.getSourceType(), nz(s.getAmount()), s.getCreatedDate());
+    }
+
+    private SkillsFundTransactionDTO toTransactionDTO(SkillsFundTransaction t) {
+        return new SkillsFundTransactionDTO(
+                t.getUuid(), t.getOrganisationUuid(), t.getDescription(), t.getTargetName(),
+                nz(t.getAmount()), t.getTransactionType(), t.getStatus(), t.getTransactionDate(), t.getCreatedDate());
+    }
+}

--- a/src/main/resources/db/migration/V202607261100__create_skills_fund.sql
+++ b/src/main/resources/db/migration/V202607261100__create_skills_fund.sql
@@ -1,0 +1,48 @@
+-- Organisation Skills Fund for the org dashboard "Skills Fund" page.
+-- Funding sources (grants, sponsors, budget) and fund transactions
+-- (allocations, disbursements, adjustments). KPIs are derived from these.
+
+CREATE TABLE skills_fund_sources
+(
+    id                BIGSERIAL PRIMARY KEY,
+    uuid              UUID                     NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+    organisation_uuid UUID                     NOT NULL,
+    name              VARCHAR(255)             NOT NULL,
+    source_type       VARCHAR(100),
+    amount            NUMERIC(19, 2)           NOT NULL        DEFAULT 0,
+
+    created_date      TIMESTAMP WITH TIME ZONE NOT NULL        DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    updated_date      TIMESTAMP WITH TIME ZONE,
+    created_by        VARCHAR(255)             NOT NULL        DEFAULT 'system',
+    updated_by        VARCHAR(255)
+);
+
+CREATE INDEX idx_skills_fund_sources_organisation ON skills_fund_sources (organisation_uuid);
+
+COMMENT ON TABLE skills_fund_sources IS
+    'Funding sources contributing to an organisation''s skills fund (grants, sponsors, budget).';
+
+CREATE TABLE skills_fund_transactions
+(
+    id                BIGSERIAL PRIMARY KEY,
+    uuid              UUID                     NOT NULL UNIQUE DEFAULT gen_random_uuid(),
+
+    organisation_uuid UUID                     NOT NULL,
+    description       VARCHAR(500),
+    target_name       VARCHAR(255),
+    amount            NUMERIC(19, 2)           NOT NULL        DEFAULT 0,
+    transaction_type  VARCHAR(50)              NOT NULL        DEFAULT 'Allocation',
+    status            VARCHAR(50)              NOT NULL        DEFAULT 'Pending',
+    transaction_date  TIMESTAMP WITH TIME ZONE,
+
+    created_date      TIMESTAMP WITH TIME ZONE NOT NULL        DEFAULT (CURRENT_TIMESTAMP AT TIME ZONE 'UTC'),
+    updated_date      TIMESTAMP WITH TIME ZONE,
+    created_by        VARCHAR(255)             NOT NULL        DEFAULT 'system',
+    updated_by        VARCHAR(255)
+);
+
+CREATE INDEX idx_skills_fund_transactions_organisation ON skills_fund_transactions (organisation_uuid);
+
+COMMENT ON TABLE skills_fund_transactions IS
+    'Skills fund movements — allocations, disbursements and adjustments — with a status lifecycle.';


### PR DESCRIPTION
Backend support for the organisation dashboard **Skills Fund** page (Lovable 1:1 port).

## Changes
- New `skills_fund_sources` + `skills_fund_transactions` tables (Flyway `V202607261100`, additive), entities, repositories, DTOs, service, and `SkillsFundController`:
  - `GET /api/v1/organisations/{organisationUuid}/skills-fund/summary` — computed KPIs (total balance, allocated, disbursed, pending, remaining)
  - `GET/POST /api/v1/organisations/{organisationUuid}/skills-fund/sources` + `DELETE /skills-fund/sources/{sourceUuid}`
  - `GET/POST /api/v1/organisations/{organisationUuid}/skills-fund/transactions` + `DELETE /skills-fund/transactions/{transactionUuid}`

## Verification
- `compileJava` + `bootJar` clean; booted locally, migration applied cleanly (`v202607261100`).
- Endpoints registered in `/v3/api-docs`; tables verified.

Migrations are additive (CREATE TABLE only). Frontend already wired on `main`; degrades gracefully until deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)