### PR TITLE
feat(course): approval-gated course content for organisations

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/course/dto/OrganisationCourseContentDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/OrganisationCourseContentDTO.java
@@ -1,0 +1,46 @@
+package apps.sarafrika.elimika.course.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Course content served to an organisation, gated by whether that organisation has an
+ * approved application to train the course.
+ * <p>
+ * Not approved: a summary the school can use to decide whether to apply — lesson outline,
+ * content counts and rating, but no lesson bodies. Approved: full read access to every
+ * lesson's content. Content is never editable here; only the course creator can edit it.
+ */
+@Schema(name = "OrganisationCourseContent", description = "Approval-gated course content for an organisation. Summary when not approved, full content when approved.")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record OrganisationCourseContentDTO(
+
+        @Schema(description = "The course this content belongs to.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty("course_uuid")
+        UUID courseUuid,
+
+        @Schema(description = "True when the organisation is approved to train and therefore has full read access.", example = "false")
+        @JsonProperty("full_access")
+        boolean fullAccess,
+
+        @Schema(description = "Total number of lessons in the course.", example = "12")
+        @JsonProperty("total_lessons")
+        int totalLessons,
+
+        @Schema(description = "Average learner rating (1-5), or null when there are no reviews.", example = "4.6")
+        @JsonProperty("average_rating")
+        Double averageRating,
+
+        @Schema(description = "Number of learner reviews.", example = "37")
+        @JsonProperty("total_reviews")
+        int totalReviews,
+
+        @Schema(description = "Lessons. Outline only until approved, then with full content.")
+        @JsonProperty("lessons")
+        List<OrganisationCourseLessonDTO> lessons
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/course/dto/OrganisationCourseLessonDTO.java
+++ b/src/main/java/apps/sarafrika/elimika/course/dto/OrganisationCourseLessonDTO.java
@@ -1,0 +1,49 @@
+package apps.sarafrika.elimika.course.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * A single lesson as seen by an organisation viewing a course.
+ * <p>
+ * When the organisation is not approved to train the course, only the outline is
+ * returned ({@code uuid} and {@code contents} are omitted) so no lesson content leaks.
+ * Once approved, the lesson {@code uuid} and full {@code contents} are included.
+ */
+@Schema(name = "OrganisationCourseLesson", description = "Lesson outline (always) plus content (only when the organisation is approved to train).")
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record OrganisationCourseLessonDTO(
+
+        @Schema(description = "Lesson identifier. Only present when the organisation has full read access.", accessMode = Schema.AccessMode.READ_ONLY)
+        @JsonProperty("uuid")
+        UUID uuid,
+
+        @Schema(description = "Ordering position of the lesson within the course.", example = "1")
+        @JsonProperty("lesson_number")
+        Integer lessonNumber,
+
+        @Schema(description = "Lesson title.", example = "Introduction to Object-Oriented Programming")
+        @JsonProperty("title")
+        String title,
+
+        @Schema(description = "Short lesson description.", example = "Classes, objects, inheritance, and polymorphism.")
+        @JsonProperty("description")
+        String description,
+
+        @Schema(description = "What the learner will be able to do after the lesson.")
+        @JsonProperty("learning_objectives")
+        String learningObjectives,
+
+        @Schema(description = "Number of content items in the lesson. Shown even in the preview so schools can gauge depth.", example = "4")
+        @JsonProperty("content_count")
+        int contentCount,
+
+        @Schema(description = "Full lesson content. Only present when the organisation has full read access.")
+        @JsonProperty("contents")
+        List<LessonContentDTO> contents
+) {
+}

--- a/src/main/java/apps/sarafrika/elimika/course/service/OrganisationCourseContentService.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/OrganisationCourseContentService.java
@@ -1,0 +1,19 @@
+package apps.sarafrika.elimika.course.service;
+
+import apps.sarafrika.elimika.course.dto.OrganisationCourseContentDTO;
+
+import java.util.UUID;
+
+/**
+ * Assembles course content for an organisation, gating lesson bodies behind an approved
+ * training application so unapproved schools only ever see the decision-making summary.
+ */
+public interface OrganisationCourseContentService {
+
+    /**
+     * @param courseUuid       the course being viewed
+     * @param organisationUuid the organisation viewing it
+     * @return outline + rating always; full lesson content only when the organisation is approved
+     */
+    OrganisationCourseContentDTO getContentForOrganisation(UUID courseUuid, UUID organisationUuid);
+}

--- a/src/main/java/apps/sarafrika/elimika/course/service/impl/OrganisationCourseContentServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/course/service/impl/OrganisationCourseContentServiceImpl.java
@@ -1,0 +1,75 @@
+package apps.sarafrika.elimika.course.service.impl;
+
+import apps.sarafrika.elimika.course.dto.CourseReviewDTO;
+import apps.sarafrika.elimika.course.dto.LessonContentDTO;
+import apps.sarafrika.elimika.course.dto.OrganisationCourseContentDTO;
+import apps.sarafrika.elimika.course.dto.OrganisationCourseLessonDTO;
+import apps.sarafrika.elimika.course.model.Lesson;
+import apps.sarafrika.elimika.course.repository.LessonRepository;
+import apps.sarafrika.elimika.course.service.CourseReviewService;
+import apps.sarafrika.elimika.course.service.CourseTrainingApplicationService;
+import apps.sarafrika.elimika.course.service.LessonContentService;
+import apps.sarafrika.elimika.course.service.OrganisationCourseContentService;
+import apps.sarafrika.elimika.course.util.enums.CourseTrainingApplicantType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.OptionalDouble;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class OrganisationCourseContentServiceImpl implements OrganisationCourseContentService {
+
+    private final LessonRepository lessonRepository;
+    private final LessonContentService lessonContentService;
+    private final CourseReviewService courseReviewService;
+    private final CourseTrainingApplicationService courseTrainingApplicationService;
+
+    @Override
+    @Transactional(readOnly = true)
+    public OrganisationCourseContentDTO getContentForOrganisation(UUID courseUuid, UUID organisationUuid) {
+        final boolean approved = courseTrainingApplicationService.hasApprovedApplication(
+                courseUuid, CourseTrainingApplicantType.ORGANISATION, organisationUuid);
+
+        final List<Lesson> lessons = lessonRepository.findByCourseUuidOrderByLessonNumberAsc(courseUuid);
+
+        final List<OrganisationCourseLessonDTO> lessonViews = lessons.stream()
+                .map(lesson -> toLessonView(lesson, approved))
+                .toList();
+
+        final List<CourseReviewDTO> reviews = courseReviewService.getReviewsForCourse(courseUuid);
+
+        return new OrganisationCourseContentDTO(
+                courseUuid,
+                approved,
+                lessons.size(),
+                averageRating(reviews),
+                reviews.size(),
+                lessonViews);
+    }
+
+    private OrganisationCourseLessonDTO toLessonView(Lesson lesson, boolean approved) {
+        final List<LessonContentDTO> content = lessonContentService.getContentByLesson(lesson.getUuid());
+        return new OrganisationCourseLessonDTO(
+                approved ? lesson.getUuid() : null,
+                lesson.getLessonNumber(),
+                lesson.getTitle(),
+                lesson.getDescription(),
+                lesson.getLearningObjectives(),
+                content.size(),
+                approved ? content : null);
+    }
+
+    private Double averageRating(List<CourseReviewDTO> reviews) {
+        final OptionalDouble average = reviews.stream()
+                .map(CourseReviewDTO::rating)
+                .filter(Objects::nonNull)
+                .mapToInt(Integer::intValue)
+                .average();
+        return average.isPresent() ? average.getAsDouble() : null;
+    }
+}

--- a/src/main/java/apps/sarafrika/elimika/shared/controller/CourseController.java
+++ b/src/main/java/apps/sarafrika/elimika/shared/controller/CourseController.java
@@ -68,6 +68,7 @@ public class CourseController {
     private final CourseCategoryService courseCategoryService;
     private final CourseReviewService courseReviewService;
     private final CourseRecommendationService courseRecommendationService;
+    private final OrganisationCourseContentService organisationCourseContentService;
     private final StorageService storageService;
     private final StorageProperties storageProperties;
     private final MediaStorageService mediaStorageService;
@@ -996,6 +997,30 @@ public class CourseController {
         List<LessonContentDTO> content = lessonContentService.getContentByLesson(lessonUuid);
         return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse
                 .success(content, "Lesson content retrieved successfully"));
+    }
+
+    @Operation(
+            summary = "Get course content for an organisation (approval-gated)",
+            description = """
+                    Returns course content scoped to what a given organisation is allowed to see.
+
+                    - **Not approved to train:** a decision-making summary — lesson outline, content
+                      counts and rating — with no lesson bodies, so full content never leaks.
+                    - **Approved to train:** full read access to every lesson's content.
+
+                    Content is read-only here regardless of access; only the course creator can edit it.
+                    """
+    )
+    @GetMapping("/{courseUuid}/organisations/{organisationUuid}/content")
+    public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<OrganisationCourseContentDTO>> getOrganisationCourseContent(
+            @PathVariable UUID courseUuid,
+            @PathVariable UUID organisationUuid) {
+        OrganisationCourseContentDTO content =
+                organisationCourseContentService.getContentForOrganisation(courseUuid, organisationUuid);
+        String message = content.fullAccess()
+                ? "Full course content retrieved"
+                : "Course summary retrieved (organisation not approved to train)";
+        return ResponseEntity.ok(apps.sarafrika.elimika.shared.dto.ApiResponse.success(content, message));
     }
 
     @Operation(


### PR DESCRIPTION
## What

Adds a single approval-gated endpoint so an organisation only sees course content it's entitled to:

`GET /api/v1/courses/{courseUuid}/organisations/{organisationUuid}/content`

| Organisation state | Returned |
|---|---|
| **Not approved to train** | Decision-making summary — lesson outline (number, title, description, objectives), per-lesson content **count**, average rating & review count. **No lesson bodies, no lesson UUIDs.** |
| **Approved to train** | Full read access — every lesson's content items included. |

Content is **read-only** regardless of access; only the course creator can edit it.

## Why

The org dashboard needs two course-detail pages — a catalogue **preview** (before applying to train) and a full **My Courses** view (after approval). Gating must be server-side so unapproved schools can't pull full lesson content (leakage). Omitting lesson UUIDs in the summary also prevents pivoting to the raw `/{courseUuid}/lessons/{lessonUuid}/content` endpoint.

## How

- New `OrganisationCourseContentService` assembles the payload, gating lesson bodies behind the existing `hasApprovedApplication(courseUuid, ORGANISATION, orgUuid)`.
- New DTOs `OrganisationCourseContentDTO` / `OrganisationCourseLessonDTO` (`@JsonInclude(NON_NULL)` so omitted fields disappear cleanly).
- One endpoint added to `CourseController`.

## Follow-up (noted, not in this PR)

The raw `GET /{courseUuid}/lessons/{lessonUuid}/content` remains auth-only (any authenticated caller). Hardening it to owner/enrolled/approved is a separate change; this PR keeps the org UI on the gated path and withholds the UUIDs it would need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)