### PR TITLE
feat(course): restrict lesson-content endpoint to authorized readers

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/course/internal/security/CourseSecurityServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/course/internal/security/CourseSecurityServiceImpl.java
@@ -2,7 +2,10 @@ package apps.sarafrika.elimika.course.internal.security;
 
 import apps.sarafrika.elimika.course.model.Course;
 import apps.sarafrika.elimika.course.repository.CourseRepository;
+import apps.sarafrika.elimika.course.repository.CourseTrainingApplicationRepository;
 import apps.sarafrika.elimika.course.spi.CourseSecuritySpi;
+import apps.sarafrika.elimika.course.util.enums.CourseTrainingApplicantType;
+import apps.sarafrika.elimika.course.util.enums.CourseTrainingApplicationStatus;
 import apps.sarafrika.elimika.coursecreator.spi.CourseCreatorLookupService;
 import apps.sarafrika.elimika.tenancy.spi.UserLookupService;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +15,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
@@ -30,6 +34,7 @@ import java.util.UUID;
 public class CourseSecurityServiceImpl implements CourseSecuritySpi {
 
     private final CourseRepository courseRepository;
+    private final CourseTrainingApplicationRepository courseTrainingApplicationRepository;
     private final CourseCreatorLookupService courseCreatorLookupService;
     private final UserLookupService userLookupService;
 
@@ -90,6 +95,55 @@ public class CourseSecurityServiceImpl implements CourseSecuritySpi {
             log.error("Error checking course ownership for course: {}", courseUuid, e);
             return false;
         }
+    }
+
+    /**
+     * Grants content read access to the course owner or a member of an organisation
+     * approved to train the course. Admins are handled at the endpoint; enrolled
+     * learners use their own class flow, not this path.
+     */
+    @Override
+    public boolean canReadCourseContent(UUID courseUuid) {
+        if (isCourseOwner(courseUuid)) {
+            return true;
+        }
+        try {
+            UUID userUuid = currentUserUuid();
+            if (userUuid == null) {
+                return false;
+            }
+            List<UUID> organisationUuids = userLookupService.getUserOrganizations(userUuid);
+            for (UUID organisationUuid : organisationUuids) {
+                boolean approved = courseTrainingApplicationRepository
+                        .existsByCourseUuidAndApplicantTypeAndApplicantUuidAndStatus(
+                                courseUuid,
+                                CourseTrainingApplicantType.ORGANISATION,
+                                organisationUuid,
+                                CourseTrainingApplicationStatus.APPROVED);
+                if (approved) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (Exception e) {
+            log.error("Error checking content read access for course: {}", courseUuid, e);
+            return false;
+        }
+    }
+
+    /**
+     * Resolves the current authenticated user's UUID from the JWT, or null.
+     */
+    private UUID currentUserUuid() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return null;
+        }
+        String keycloakId = getKeycloakId(authentication);
+        if (keycloakId == null) {
+            return null;
+        }
+        return userLookupService.findUserUuidByKeycloakId(keycloakId).orElse(null);
     }
 
     /**

--- a/src/main/java/apps/sarafrika/elimika/course/spi/CourseSecuritySpi.java
+++ b/src/main/java/apps/sarafrika/elimika/course/spi/CourseSecuritySpi.java
@@ -19,4 +19,16 @@ public interface CourseSecuritySpi {
      * @return true if the current user owns the course, false otherwise
      */
     boolean isCourseOwner(UUID courseUuid);
+
+    /**
+     * Checks whether the current user may read the course's lesson content.
+     * <p>
+     * True for the course owner or a member of an organisation approved to train
+     * the course. Platform admins are granted separately at the endpoint. Enrolled
+     * learners read content through their own class flow, not this path.
+     *
+     * @param courseUuid UUID of the course to check
+     * @return true if the current user may read the course content, false otherwise
+     */
+    boolean canReadCourseContent(UUID courseUuid);
 }

--- a/src/main/java/apps/sarafrika/elimika/shared/controller/CourseController.java
+++ b/src/main/java/apps/sarafrika/elimika/shared/controller/CourseController.java
@@ -988,8 +988,15 @@ public class CourseController {
 
     @Operation(
             summary = "Get lesson content",
-            description = "Retrieves all content for a lesson in display order with computed properties."
+            description = """
+                    Retrieves all content for a lesson in display order with computed properties.
+
+                    Restricted to the course owner, a member of an organisation approved to train
+                    the course, or a platform admin — so lesson content is never readable by
+                    arbitrary authenticated callers.
+                    """
     )
+    @PreAuthorize("@courseSecurityService.canReadCourseContent(#courseUuid) or @domainSecurityService.isPlatformAdmin()")
     @GetMapping("/{courseUuid}/lessons/{lessonUuid}/content")
     public ResponseEntity<apps.sarafrika.elimika.shared.dto.ApiResponse<List<LessonContentDTO>>> getLessonContent(
             @PathVariable UUID courseUuid,


### PR DESCRIPTION
## What

`GET /api/v1/courses/{courseUuid}/lessons/{lessonUuid}/content` returned lesson content to **any authenticated caller**. It's now gated:

```
@PreAuthorize("@courseSecurityService.canReadCourseContent(#courseUuid) or @domainSecurityService.isPlatformAdmin()")
```

`canReadCourseContent(courseUuid)` = the **course owner**, or a **member of an organisation approved to train** the course (resolved via `UserLookupService.getUserOrganizations` + the existing approved-application check).

## Why

Follow-up to the org content-gating work (#262). That gave orgs a gated aggregate endpoint, but the raw per-lesson endpoint still let an unapproved school pull full content by lesson UUID. This closes that direct-read leak.

## Safety

- **Only current caller is the course-creator (owner) UI** (`@course_creator/*` lesson/content forms) — covered by `isCourseOwner`, unaffected.
- Students read content through their own class flow, **not** this endpoint — not broken.
- No new module dependencies: uses the same-module `CourseTrainingApplicationRepository` + already-allowed `tenancy-spi`. Enrolled-student access was intentionally left out to avoid a `student-spi` boundary dependency (and students don't use this path).

## Residual (noted, not here)

`GET /courses/content-media/{*filePath}` is still `permitAll` (serves files by storage-key path). Protecting that is a broader, separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)