### PR TITLE
feat(classes): recruitment funnel stages for marketplace applications

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/classes/controller/ClassMarketplaceJobController.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/controller/ClassMarketplaceJobController.java
@@ -236,12 +236,22 @@ public class ClassMarketplaceJobController {
         ClassMarketplaceJobApplicationDTO result = switch (action.toLowerCase()) {
             case "approve" -> classMarketplaceJobService.approveApplication(jobUuid, applicationUuid, payload);
             case "reject" -> classMarketplaceJobService.rejectApplication(jobUuid, applicationUuid, payload);
-            default -> throw new IllegalArgumentException("Unsupported action '" + action + "'. Allowed values: approve, reject.");
+            case "shortlist" -> classMarketplaceJobService.moveApplicationToStage(jobUuid, applicationUuid,
+                    apps.sarafrika.elimika.classes.util.enums.ClassMarketplaceJobApplicationStatus.SHORTLISTED, payload);
+            case "interview" -> classMarketplaceJobService.moveApplicationToStage(jobUuid, applicationUuid,
+                    apps.sarafrika.elimika.classes.util.enums.ClassMarketplaceJobApplicationStatus.INTERVIEWING, payload);
+            case "offer" -> classMarketplaceJobService.moveApplicationToStage(jobUuid, applicationUuid,
+                    apps.sarafrika.elimika.classes.util.enums.ClassMarketplaceJobApplicationStatus.OFFERED, payload);
+            default -> throw new IllegalArgumentException("Unsupported action '" + action
+                    + "'. Allowed values: shortlist, interview, offer, approve, reject.");
         };
 
         String message = switch (action.toLowerCase()) {
             case "approve" -> "Marketplace class job application approved successfully";
             case "reject" -> "Marketplace class job application rejected successfully";
+            case "shortlist" -> "Candidate shortlisted successfully";
+            case "interview" -> "Candidate moved to interview successfully";
+            case "offer" -> "Offer extended to candidate successfully";
             default -> "Marketplace class job application updated successfully";
         };
 

--- a/src/main/java/apps/sarafrika/elimika/classes/service/ClassMarketplaceJobServiceInterface.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/service/ClassMarketplaceJobServiceInterface.java
@@ -57,6 +57,15 @@ public interface ClassMarketplaceJobServiceInterface {
                                                         UUID applicationUuid,
                                                         ClassMarketplaceJobDecisionRequestDTO request);
 
+    /**
+     * Moves an application to a non-terminal recruitment stage
+     * (SHORTLISTED, INTERVIEWING or OFFERED) without making a final decision.
+     */
+    ClassMarketplaceJobApplicationDTO moveApplicationToStage(UUID jobUuid,
+                                                             UUID applicationUuid,
+                                                             ClassMarketplaceJobApplicationStatus targetStage,
+                                                             ClassMarketplaceJobDecisionRequestDTO request);
+
     ClassMarketplaceJobAssignmentResponseDTO assignInstructor(UUID jobUuid,
                                                               ClassMarketplaceJobAssignmentRequestDTO request);
 }

--- a/src/main/java/apps/sarafrika/elimika/classes/service/impl/ClassMarketplaceJobServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/service/impl/ClassMarketplaceJobServiceImpl.java
@@ -333,6 +333,33 @@ public class ClassMarketplaceJobServiceImpl implements ClassMarketplaceJobServic
     }
 
     @Override
+    public ClassMarketplaceJobApplicationDTO moveApplicationToStage(UUID jobUuid,
+                                                                    UUID applicationUuid,
+                                                                    ClassMarketplaceJobApplicationStatus targetStage,
+                                                                    ClassMarketplaceJobDecisionRequestDTO request) {
+        if (targetStage != ClassMarketplaceJobApplicationStatus.SHORTLISTED
+                && targetStage != ClassMarketplaceJobApplicationStatus.INTERVIEWING
+                && targetStage != ClassMarketplaceJobApplicationStatus.OFFERED) {
+            throw new IllegalArgumentException("Stage " + targetStage
+                    + " is not a movable recruitment stage. Use approve, reject or assign for final decisions.");
+        }
+
+        ClassMarketplaceJob job = getJobEntity(jobUuid);
+        ensureJobOpen(job);
+        requireOrganisationManagerAccess(job.getOrganisationUuid());
+
+        ClassMarketplaceJobApplication application = getApplication(jobUuid, applicationUuid);
+        ensureApplicationReviewable(application);
+
+        application.setStatus(targetStage);
+        application.setReviewNotes(request == null ? null : request.reviewNotes());
+        application.setReviewedBy(resolveReviewer());
+        application.setReviewedAt(LocalDateTime.now(ZoneOffset.UTC));
+
+        return toApplicationDTO(applicationRepository.save(application), job);
+    }
+
+    @Override
     public ClassMarketplaceJobAssignmentResponseDTO assignInstructor(UUID jobUuid,
                                                                      ClassMarketplaceJobAssignmentRequestDTO request) {
         ClassMarketplaceJob job = getJobEntity(jobUuid);

--- a/src/main/java/apps/sarafrika/elimika/classes/util/enums/ClassMarketplaceJobApplicationStatus.java
+++ b/src/main/java/apps/sarafrika/elimika/classes/util/enums/ClassMarketplaceJobApplicationStatus.java
@@ -11,6 +11,9 @@ import java.util.Map;
  */
 public enum ClassMarketplaceJobApplicationStatus {
     PENDING("pending"),
+    SHORTLISTED("shortlisted"),
+    INTERVIEWING("interviewing"),
+    OFFERED("offered"),
     APPROVED("approved"),
     REJECTED("rejected"),
     ASSIGNED("assigned"),

--- a/src/main/resources/db/migration/V202607271300__add_recruitment_stages_to_marketplace_applications.sql
+++ b/src/main/resources/db/migration/V202607271300__add_recruitment_stages_to_marketplace_applications.sql
@@ -1,0 +1,12 @@
+-- Add recruitment-funnel stages (shortlisted / interviewing / offered) to a
+-- marketplace job application, between the applicant applying (PENDING) and the
+-- final approve/assign/reject decisions.
+ALTER TABLE class_marketplace_job_applications
+    DROP CONSTRAINT IF EXISTS chk_class_marketplace_job_applications_status;
+
+ALTER TABLE class_marketplace_job_applications
+    ADD CONSTRAINT chk_class_marketplace_job_applications_status
+        CHECK (status IN (
+            'PENDING', 'SHORTLISTED', 'INTERVIEWING', 'OFFERED',
+            'APPROVED', 'REJECTED', 'ASSIGNED', 'NOT_SELECTED'
+        ));


### PR DESCRIPTION
## What

Adds **SHORTLISTED / INTERVIEWING / OFFERED** stages to a marketplace job application, so the org can run candidates through a real recruitment pipeline (Applied → Shortlist → Interview → Offer → Approve/Hire) on the Job Matches board — instead of a client-only funnel.

- Enum values + additive check-constraint migration
- `moveApplicationToStage(job, application, stage)` — org-manager gated, reuses `ensureApplicationReviewable`, sets reviewer + timestamp; only allows the three non-terminal stages (final decisions still go through approve/reject/assign)
- `reviewApplication` endpoint gains `shortlist` / `interview` / `offer` actions next to the existing `approve` / `reject` — **no new endpoint, no client contract change**

## Why

Frontend port of the redesigned Lovable Job Matches page + candidate detail needs a real, movable pipeline. This backs it end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)