### PR TITLE
fix(enrolment): stop a checkout seat hold from reading back as an enrolment

### DIFF
--- a/src/main/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImpl.java
+++ b/src/main/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImpl.java
@@ -1218,15 +1218,39 @@ public class TimetableServiceImpl implements TimetableService {
         }
 
         List<ScheduledInstance> instances = scheduledInstanceRepository.findByClassDefinitionUuid(classDefinitionUuid);
-        Set<UUID> held = enrollmentRepository.findByStudentUuid(studentUuid).stream()
+        List<Enrollment> studentEnrollments = enrollmentRepository.findByStudentUuid(studentUuid);
+        LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
+
+        // The seat this buyer is holding at checkout is their own, so it must not be read back as an
+        // enrolment: doing so refuses the very purchase that took the hold. A cancelled seat is not
+        // an enrolment either. Only rows that mean "this student has this seat" count here.
+        Set<UUID> enrolledInstances = studentEnrollments.stream()
+                .filter(enrollment -> enrollment.getStatus() != EnrollmentStatus.RESERVED
+                        && enrollment.getStatus() != EnrollmentStatus.CANCELLED)
+                .map(Enrollment::getScheduledInstanceUuid)
+                .collect(Collectors.toSet());
+
+        // Seats this student occupies and therefore does not need to buy again. A live hold counts;
+        // one that has lapsed does not, or a buyer whose payment never resolved would be locked out
+        // of the class for good.
+        Set<UUID> occupiedInstances = studentEnrollments.stream()
+                .filter(enrollment -> enrollment.getStatus() != EnrollmentStatus.CANCELLED)
+                .filter(enrollment -> !hasLapsed(enrollment, now))
                 .map(Enrollment::getScheduledInstanceUuid)
                 .collect(Collectors.toSet());
 
         boolean alreadyEnrolled = !instances.isEmpty()
-                && instances.stream().allMatch(instance -> held.contains(instance.getUuid()));
-        boolean seatsAvailable = instances.stream()
-                .filter(instance -> !held.contains(instance.getUuid()))
-                .anyMatch(instance -> hasCapacityForEnrollment(instance.getUuid()));
+                && instances.stream().allMatch(instance -> enrolledInstances.contains(instance.getUuid()));
+
+        List<ScheduledInstance> instancesNeedingSeat = instances.stream()
+                .filter(instance -> !occupiedInstances.contains(instance.getUuid()))
+                .toList();
+        // Holding every seat already is not the same as the class being full: there is nothing left
+        // to take, so reporting "full" here would block a purchase that needs no new seat.
+        boolean seatsAvailable = !instances.isEmpty()
+                && (instancesNeedingSeat.isEmpty()
+                        || instancesNeedingSeat.stream()
+                                .anyMatch(instance -> hasCapacityForEnrollment(instance.getUuid())));
 
         String reason = null;
         if (!dateOfBirthOnFile) {
@@ -1253,6 +1277,16 @@ public class TimetableServiceImpl implements TimetableService {
                 seatsAvailable,
                 alreadyEnrolled,
                 reason);
+    }
+
+    /**
+     * True when this row is a seat hold whose window has closed. A hold with no expiry is open ended
+     * and never lapses; anything that is not a hold cannot lapse either.
+     */
+    private boolean hasLapsed(Enrollment enrollment, LocalDateTime now) {
+        return enrollment.getStatus() == EnrollmentStatus.RESERVED
+                && enrollment.getReservedUntil() != null
+                && enrollment.getReservedUntil().isBefore(now);
     }
 
     private void enforceClassAgeLimits(UUID studentUuid, UUID classDefinitionUuid) {

--- a/src/test/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImplTest.java
+++ b/src/test/java/apps/sarafrika/elimika/timetabling/service/impl/TimetableServiceImplTest.java
@@ -734,6 +734,114 @@ class TimetableServiceImplTest {
         assertThat(eligibility.reason()).contains("no scheduled sessions");
     }
 
+    @Test
+    void aSeatHeldAtCheckoutIsNotReadBackAsAnEnrolment() {
+        UUID classUuid = UUID.randomUUID();
+        UUID courseUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        noAgeLimit(classUuid, courseUuid);
+        ScheduledInstance first = instanceOf(classUuid);
+        ScheduledInstance second = instanceOf(classUuid);
+        when(scheduledInstanceRepository.findByClassDefinitionUuid(classUuid))
+                .thenReturn(List.of(first, second));
+        when(enrollmentRepository.findByStudentUuid(studentUuid)).thenReturn(List.of(
+                heldSeat(studentUuid, first.getUuid(), LocalDateTime.now(java.time.ZoneOffset.UTC).plusMinutes(10)),
+                heldSeat(studentUuid, second.getUuid(), LocalDateTime.now(java.time.ZoneOffset.UTC).plusMinutes(10))));
+
+        var eligibility = timetableService.getClassEnrolmentEligibility(classUuid, studentUuid);
+
+        // The hold taken moments earlier at checkout is this buyer's own seat. Reading it back as an
+        // enrolment refused the purchase that took it, which stranded the order and the money.
+        assertThat(eligibility.alreadyEnrolled()).isFalse();
+        assertThat(eligibility.seatsAvailable()).isTrue();
+        assertThat(eligibility.eligible()).isTrue();
+        assertThat(eligibility.reason()).isNull();
+    }
+
+    @Test
+    void aHoldThatLapsedDoesNotLockTheStudentOutOfTheClass() {
+        UUID classUuid = UUID.randomUUID();
+        UUID courseUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        noAgeLimit(classUuid, courseUuid);
+        ScheduledInstance instance = instanceOf(classUuid);
+        when(scheduledInstanceRepository.findByClassDefinitionUuid(classUuid)).thenReturn(List.of(instance));
+        when(enrollmentRepository.findByStudentUuid(studentUuid)).thenReturn(List.of(
+                heldSeat(studentUuid, instance.getUuid(), LocalDateTime.now(java.time.ZoneOffset.UTC).minusDays(6))));
+        when(scheduledInstanceRepository.findByUuid(instance.getUuid())).thenReturn(Optional.of(instance));
+        when(enrollmentRepository.countActiveEnrollmentsByScheduledInstance(instance.getUuid())).thenReturn(1L);
+
+        var eligibility = timetableService.getClassEnrolmentEligibility(classUuid, studentUuid);
+
+        // A payment that never resolved leaves the hold behind. Treating it as a standing claim would
+        // bar this learner from ever buying the class again.
+        assertThat(eligibility.alreadyEnrolled()).isFalse();
+        assertThat(eligibility.eligible()).isTrue();
+    }
+
+    @Test
+    void aStudentWithASeatOnEveryInstanceIsStillTurnedAway() {
+        UUID classUuid = UUID.randomUUID();
+        UUID courseUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        noAgeLimit(classUuid, courseUuid);
+        ScheduledInstance instance = instanceOf(classUuid);
+        when(scheduledInstanceRepository.findByClassDefinitionUuid(classUuid)).thenReturn(List.of(instance));
+        Enrollment enrolled = heldSeat(studentUuid, instance.getUuid(), null);
+        enrolled.setStatus(EnrollmentStatus.ENROLLED);
+        when(enrollmentRepository.findByStudentUuid(studentUuid)).thenReturn(List.of(enrolled));
+
+        var eligibility = timetableService.getClassEnrolmentEligibility(classUuid, studentUuid);
+
+        assertThat(eligibility.alreadyEnrolled()).isTrue();
+        assertThat(eligibility.eligible()).isFalse();
+        assertThat(eligibility.reason()).contains("already enrolled");
+    }
+
+    @Test
+    void aCancelledSeatLetsTheStudentBuyTheClassAgain() {
+        UUID classUuid = UUID.randomUUID();
+        UUID courseUuid = UUID.randomUUID();
+        UUID studentUuid = UUID.randomUUID();
+        noAgeLimit(classUuid, courseUuid);
+        ScheduledInstance instance = instanceOf(classUuid);
+        when(scheduledInstanceRepository.findByClassDefinitionUuid(classUuid)).thenReturn(List.of(instance));
+        Enrollment cancelled = heldSeat(studentUuid, instance.getUuid(), null);
+        cancelled.setStatus(EnrollmentStatus.CANCELLED);
+        when(enrollmentRepository.findByStudentUuid(studentUuid)).thenReturn(List.of(cancelled));
+        when(scheduledInstanceRepository.findByUuid(instance.getUuid())).thenReturn(Optional.of(instance));
+        when(enrollmentRepository.countActiveEnrollmentsByScheduledInstance(instance.getUuid())).thenReturn(0L);
+
+        var eligibility = timetableService.getClassEnrolmentEligibility(classUuid, studentUuid);
+
+        assertThat(eligibility.alreadyEnrolled()).isFalse();
+        assertThat(eligibility.eligible()).isTrue();
+    }
+
+    private void noAgeLimit(UUID classDefinitionUuid, UUID courseUuid) {
+        when(classDefinitionLookupService.findByUuid(classDefinitionUuid))
+                .thenReturn(Optional.of(new apps.sarafrika.elimika.shared.spi.ClassDefinitionLookupService.ClassDefinitionSnapshot(
+                        classDefinitionUuid, courseUuid, null, "Dairy", null,
+                        null, null, apps.sarafrika.elimika.shared.utils.enums.RateBasis.PER_HOUR, null, null, 20, true, 30)));
+        when(courseInfoService.getAgeLimits(courseUuid)).thenReturn(Optional.empty());
+    }
+
+    private ScheduledInstance instanceOf(UUID classDefinitionUuid) {
+        ScheduledInstance instance = buildScheduledInstance(UUID.randomUUID(), SchedulingStatus.SCHEDULED);
+        instance.setClassDefinitionUuid(classDefinitionUuid);
+        return instance;
+    }
+
+    private Enrollment heldSeat(UUID studentUuid, UUID scheduledInstanceUuid, LocalDateTime reservedUntil) {
+        Enrollment enrollment = new Enrollment();
+        enrollment.setUuid(UUID.randomUUID());
+        enrollment.setScheduledInstanceUuid(scheduledInstanceUuid);
+        enrollment.setStudentUuid(studentUuid);
+        enrollment.setStatus(EnrollmentStatus.RESERVED);
+        enrollment.setReservedUntil(reservedUntil);
+        return enrollment;
+    }
+
     private Enrollment buildEnrollment(EnrollmentStatus status) {
         Enrollment enrollment = new Enrollment();
         enrollment.setUuid(UUID.randomUUID());


### PR DESCRIPTION
# Summary

Checkout was blocking itself with its own seat hold, so no student could enrol and the student dashboard could not be tested.

`completeCart` reserves a seat on every scheduled instance of the class before payment. `OrderServiceImpl.completeCheckout` then re-asked the eligibility gate, which counted those `RESERVED` rows as enrolments and answered "You are already enrolled in this class" — a 409 on a checkout that had already persisted the order, the cart completion and the holds. The UI catches that as a failed payment start, so `pay/mpesa` is never called and the order is stranded at `AWAITING_PAYMENT`.

The same gate runs again in `OrderPaymentServiceImpl.getPaymentStatus` after M-Pesa confirms, where it would have produced `REFUSED CAPTURE` — money collected by Safaricom, no seat granted, manual reversal required. That path is fixed by the same change.

Observed on staging: one checkout attempt ever (2026-08-17), 409, order `66c9450d` still `PENDING/AWAITING_PAYMENT` with no `checkout_request_id` and zero rows in `commerce_payment`.

# Linked Issue

- N/A

# Changes

## Enrolment Eligibility

- `getClassEnrolmentEligibility` now derives two sets from the student's rows instead of one:
  - `enrolledInstances` — excludes `RESERVED` and `CANCELLED`; drives `alreadyEnrolled`, so a buyer's own hold is no longer read back as an enrolment
  - `occupiedInstances` — seats the student need not buy again; a live hold counts, a lapsed one does not, so an unresolved payment no longer locks the learner out of the class permanently
- `seatsAvailable` returns true when the student already occupies every instance, instead of reporting "This class is full" — otherwise the fix would have swapped one false blocker for another
- added `hasLapsed`, which treats a `RESERVED` row past `reserved_until` as no longer held

This mirrors what `enrollStudent` already does, where `RESERVED` is deliberately excluded so a held seat is promoted rather than skipped.

# Tests

## Executed

- `./gradlew test` — 841 tests, 0 failures, 0 errors

## Added Coverage

- a live hold on every instance leaves the student eligible, with `alreadyEnrolled` false
- a hold past its expiry does not lock the student out of the class
- a student genuinely enrolled on every instance is still refused
- a cancelled seat lets the student buy the class again

# Configuration / Secret Impacts

- none; no new environment variables, no migration

# Migration and Rollout Notes

- lapsed `RESERVED` rows already in the database still consume instance capacity, because `countActiveEnrollmentsByScheduledInstance` counts them. Staging has three, all belonging to the stranded 2026-08-17 order; they should be released to `CANCELLED` so the class frees up.

# Reviewer Notes

- `seatsAvailable` semantics changed for an already-enrolled student: it now reports true rather than false. `eligible` and `reason` are unaffected, since `alreadyEnrolled` is checked first in the reason ladder.
- Out of scope, worth a follow-up: nothing sweeps lapsed holds back to `CANCELLED`. `MpesaPaymentReconciliationScheduler` only picks up orders with a non-null `checkout_request_id`, so a checkout that dies before the STK push is invisible to it, and its holds keep consuming capacity from other buyers indefinitely.
